### PR TITLE
enforce component names are normal lowercase

### DIFF
--- a/src/core/errors.rs
+++ b/src/core/errors.rs
@@ -24,6 +24,8 @@ pub enum CliError {
     MissingConfig,
     /// Component not found in manifest
     MissingComponent(String),
+    /// Value in manifest is not lowercase
+    InvalidComponentName(String),
     /// Manifest cannot be overwritten without forcing
     ManifestExists,
     /// Executable we shell out to is missing
@@ -150,6 +152,9 @@ impl fmt::Display for CliError {
             CliError::MissingConfig => write!(f, "No ~/.lal/config found"),
             CliError::MissingComponent(ref s) => {
                 write!(f, "Component '{}' not found in manifest", s)
+            }
+            CliError::InvalidComponentName(ref s) => {
+                write!(f, "Invalid component name {} - not lowercase", s)
             }
             CliError::ManifestExists => write!(f, "Manifest already exists (use -f to force)"),
             CliError::MissingDependencies => {

--- a/src/core/manifest.rs
+++ b/src/core/manifest.rs
@@ -149,12 +149,25 @@ impl Manifest {
     /// Verify assumptions about configurations
     pub fn verify(&self) -> LalResult<()> {
         for (name, conf) in &self.components {
+            if &name.to_lowercase() != name {
+                return Err(CliError::InvalidComponentName(name.clone()))
+            }
             // Verify ComponentSettings (manifest.components[x])
             debug!("Verifying component {}", name);
             if !conf.configurations.contains(&conf.defaultConfig) {
                 let ename = format!("default configuration '{}' not found in configurations list",
                                     conf.defaultConfig);
                 return Err(CliError::InvalidBuildConfiguration(ename));
+            }
+        }
+        for (name, _) in &self.dependencies {
+            if &name.to_lowercase() != name {
+                return Err(CliError::InvalidComponentName(name.clone()))
+            }
+        }
+        for (name, _) in &self.devDependencies {
+            if &name.to_lowercase() != name {
+                return Err(CliError::InvalidComponentName(name.clone()))
             }
         }
         Ok(())

--- a/src/export.rs
+++ b/src/export.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::Path;
 
 use storage::CachedBackend;
-use super::LalResult;
+use super::{LalResult, CliError};
 
 /// Export a specific component from the storage backend
 pub fn export<T: CachedBackend + ?Sized>(
@@ -11,8 +11,11 @@ pub fn export<T: CachedBackend + ?Sized>(
     output: Option<&str>,
     env: Option<&str>,
 ) -> LalResult<()> {
-    let dir = output.unwrap_or(".");
+    if comp.to_lowercase() != comp {
+        return Err(CliError::InvalidComponentName(comp.into()))
+    }
 
+    let dir = output.unwrap_or(".");
     info!("Export {} {} to {}", env.unwrap_or("global"), comp, dir);
 
     let mut component_name = comp; // this is only correct if no =version suffix

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -21,6 +21,9 @@ pub fn fetch<T: CachedBackend + ?Sized>(
     core: bool,
     env: &str,
 ) -> LalResult<()> {
+    // first ensure manifest is sane:
+    manifest.verify()?;
+
     debug!("Installing dependencies{}",
            if !core { " and devDependencies" } else { "" });
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,10 +1,13 @@
 use std::io::{self, Write};
 
 use storage::Backend;
-use super::LalResult;
+use super::{LalResult, CliError};
 
 /// Prints a list of versions associated with a component
 pub fn query(backend: &Backend, env: Option<&str>, component: &str, last: bool) -> LalResult<()> {
+    if component.to_lowercase() != component {
+        return Err(CliError::InvalidComponentName(component.into()))
+    }
     if last {
         let ver = backend.get_latest_version(component, env)?;
         println!("{}", ver);

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,5 +1,5 @@
 use storage::CachedBackend;
-use super::{LalResult, Manifest};
+use super::{LalResult, Manifest, CliError};
 
 /// Update specific dependencies outside the manifest
 ///
@@ -26,6 +26,9 @@ pub fn update<T: CachedBackend + ?Sized>(
         if comp.contains('=') {
             let pair: Vec<&str> = comp.split('=').collect();
             if let Ok(n) = pair[1].parse::<u32>() {
+                if pair[0].to_lowercase() != pair[0] {
+                    return Err(CliError::InvalidComponentName(pair[0].into()))
+                }
                 // standard fetch with an integer version
                 match backend.unpack_published_component(pair[0], Some(n), Some(env)) {
                     Ok(c) => updated.push(c),
@@ -43,6 +46,9 @@ pub fn update<T: CachedBackend + ?Sized>(
                 });
             }
         } else {
+            if &comp.to_lowercase() != comp {
+                return Err(CliError::InvalidComponentName(comp.clone()))
+            }
             // fetch without a specific version (latest)
             match backend.unpack_published_component(comp, None, Some(env)) {
                 Ok(c) => updated.push(c),


### PR DESCRIPTION
originally started this to avoid invalid paths, but turns out we can have a path of unicode characters like; `ὀδυσσεύς`.

thus non-unicode paths in cache should be impossible because the manifest only allows strings (unicode) in the manifest anyway.

however, this is checking that the component names are lowercase, because don't want to have case sensitivity there. this means a component name like: `ὈΔΥΣΣΕΎΣ` is disallowed.

the lowercase check is thus put everywhere.

maybe we want to upgrade it to ascii lowercase only though..