### PR TITLE
starts of a GithubBackend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ chrono = "0.2"
 clap = "2.27.1"
 filetime = "0.1"
 flate2 = "0.2"
+#hubcaps = { git = "https://github.com/lalbuild/hubcaps" }
 hyper = "0.10.9"
 hyper-native-tls = "0.2.2"
 log = "0.3.5"

--- a/src/core/errors.rs
+++ b/src/core/errors.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::io;
 use hyper;
 use serde_json;
+use hubcaps;
 
 /// The one and only error type for the lal library
 ///
@@ -16,6 +17,8 @@ pub enum CliError {
     Parse(serde_json::error::Error),
     /// Errors propagated from `hyper`
     Hype(hyper::Error),
+    /// Errors propagated form `hubcaps
+    Github(hubcaps::Error),
 
     // main errors
     /// Manifest file not found in working directory
@@ -137,6 +140,7 @@ impl fmt::Display for CliError {
             }
             CliError::Parse(ref err) => err.fmt(f),
             CliError::Hype(ref err) => err.fmt(f),
+            CliError::Github(ref err) => err.fmt(f),
             CliError::MissingManifest => {
                 write!(f,
                        "No manifest.json found - are you at repository toplevel?")
@@ -269,6 +273,12 @@ impl From<hyper::Error> for CliError {
 impl From<serde_json::error::Error> for CliError {
     fn from(err: serde_json::error::Error) -> CliError { CliError::Parse(err) }
 }
+
+impl From<hubcaps::Error> for CliError {
+    fn from(err: hubcaps::Error) -> CliError { CliError::Github(err) }
+}
+
+
 
 /// Type alias to stop having to type out `CliError` everywhere.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ extern crate tar;
 extern crate flate2;
 extern crate ansi_term;
 extern crate sha1;
+extern crate hubcaps;
 #[macro_use]
 extern crate log;
 extern crate walkdir;

--- a/src/main.rs
+++ b/src/main.rs
@@ -571,6 +571,9 @@ fn main() {
         &BackendConfiguration::Local(ref local_cfg) => {
             Box::new(LocalBackend::new(&local_cfg, &config.cache))
         }
+        &BackendConfiguration::Github(ref gh_cfg) => {
+            Box::new(GithubBackend::new(&gh_cfg, &config.cache))
+        }
     };
 
     // Ensure SSL is initialized before using the backend

--- a/src/storage/github.rs
+++ b/src/storage/github.rs
@@ -1,0 +1,126 @@
+#![allow(missing_docs)]
+#![allow(unused_variables)]
+#![allow(unused_imports)]
+use std::vec::Vec;
+
+use std::fs::File;
+use std::path::{Path, PathBuf};
+
+
+use hyper::Client;
+use hyper::net::HttpsConnector;
+use hyper_native_tls::NativeTlsClient;
+use hubcaps::{Credentials, Github};
+
+use hubcaps::releases::{Release, Releases, ReleaseOptions, ReleaseOptionsBuilder};
+
+use core::{CliError, LalResult};
+
+
+/// Github credentials
+#[derive(Serialize, Deserialize, Clone)]
+pub struct GithubCredentials {
+    /// Personal access token with upload access
+    pub token: String,
+}
+
+/// Static Github locations
+#[derive(Serialize, Deserialize, Clone, Default)]
+pub struct GithubConfig {
+    /// Github organisation
+    pub organisation: String,
+    /// Optional upload credentials
+    pub credentials: Option<GithubCredentials>,
+}
+
+use super::{Backend, Component};
+
+/// Everything we need for Github to implement the Backend trait
+pub struct GithubBackend {
+    /// Github config and credentials
+    pub config: GithubConfig,
+    /// Cache directory
+    pub cache: String,
+    /// Github client with a tls configured hyper client
+    pub client: Github,
+}
+
+impl GithubBackend {
+    pub fn new(cfg: &GithubConfig, cache: &str) -> Self {
+        let creds = if let Some(c) = cfg.credentials.clone() {
+            Credentials::Token(c.token)
+        } else {
+            Credentials::default()
+        };
+        let github = Github::new(
+            format!("lal/{}", env!("CARGO_PKG_VERSION")),
+            Client::with_connector(HttpsConnector::new(NativeTlsClient::new().unwrap())),
+            creds
+        );
+
+        GithubBackend {
+            config: cfg.clone(),
+            client: github,
+            cache: cache.into(),
+        }
+    }
+}
+
+
+/// Artifact backend trait for `GithubBackend`
+///
+/// This is intended to be used by the caching trait `CachedBackend`, but for
+/// specific low-level use cases, these methods can be used directly.
+impl Backend for GithubBackend {
+    fn get_versions(&self, name: &str, loc: &str) -> LalResult<Vec<u32>> {
+        unimplemented!();
+    }
+
+    fn get_latest_version(&self, name: &str, loc: &str) -> LalResult<u32> {
+        unimplemented!();
+    }
+
+    fn get_component_info(
+        &self,
+        name: &str,
+        version: Option<u32>,
+        loc: &str,
+    ) -> LalResult<Component> {
+        unimplemented!();
+    }
+
+    fn publish_artifact(&self, name: &str, version: u32, env: &str) -> LalResult<()> {
+        // this fn basically assumes all the sanity checks have been performed
+        // files must exist and lockfile must be sensible
+        let artdir = Path::new("./ARTIFACT");
+        let tarball = artdir.join(format!("{}.tar.gz", name));
+        let lockfile = artdir.join("lockfile.json");
+
+
+        // 1. create a release
+        // TODO: needs sha from lockfile?
+        let res = Releases::new(&self.client, self.config.organisation.clone(), name);
+        let opts = ReleaseOptionsBuilder::new(version.to_string()).build();
+        let release : Release = res.create(&opts)?;
+
+        // 2. create an asset on this release
+        // TODO: this part of the api is missing from hubcaps
+
+        // uri prefix if specific env upload
+        //let prefix = format!("env/{}/", env);
+        //let tar_uri = format!("{}{}/{}/{}.tar.gz", prefix, name, version, name);
+        //let mut tarf = File::open(tarball)?;
+        //upload_artifact(&self.config, &tar_uri, &mut tarf)?;
+
+        //let mut lockf = File::open(lockfile)?;
+        //let lf_uri = format!("{}{}/{}/lockfile.json", prefix, name, version);
+        //upload_artifact(&self.config, &lf_uri, &mut lockf)?;
+        unimplemented!();
+    }
+
+    fn get_cache_dir(&self) -> String { self.cache.clone() }
+
+    fn raw_fetch(&self, url: &str, dest: &PathBuf) -> LalResult<()> {
+        unimplemented!();
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -2,15 +2,18 @@ pub use self::traits::{BackendConfiguration, Backend, CachedBackend, Component};
 
 pub use self::artifactory::{ArtifactoryConfig, Credentials, ArtifactoryBackend};
 pub use self::local::{LocalConfig, LocalBackend};
+pub use self::github::{GithubConfig, GithubCredentials, GithubBackend};
 
 // Some special exports for lal upgrade - canonical releases are on artifactory atm
 #[cfg(feature = "upgrade")]
 pub use self::artifactory::{LatestLal, get_latest_lal_version, http_download_to_path};
 
 mod traits;
-mod artifactory;
-mod local;
 mod download;
+
+mod local;
+mod artifactory;
+mod github;
 
 #[cfg(feature = "progress")]
 mod progress;

--- a/src/storage/traits.rs
+++ b/src/storage/traits.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use core::LalResult;
-use super::{ArtifactoryConfig, LocalConfig};
+use super::{ArtifactoryConfig, LocalConfig, GithubConfig};
 
 /// An enum struct for the currently configured `Backend`
 ///
@@ -16,6 +16,10 @@ pub enum BackendConfiguration {
     /// Config for the `LocalBackend`
     #[serde(rename = "local")]
     Local(LocalConfig),
+
+    /// Config for the `GithubBackend`
+    #[serde(rename = "github")]
+    Github(GithubConfig),
 }
 
 /// Artifactory is the default backend


### PR DESCRIPTION
Needs a new version of hubcaps that supports release assets before this can be used, but this contains the preliminary type setup. This would implement #1 


Got stuck on having to add logic to hubcaps.
Think I had it almost working in https://github.com/lalbuild/hubcaps/commit/a13f4400b09ca04c83070f80eed105c971033a05

- [ ] need to upgrade hyper to use new hubcaps (about time anyway)
- [ ] fix progressbars for tokio (see [indicatif tokio example](https://github.com/mitsuhiko/indicatif/blob/master/examples/tokio.rs) )
- [ ] actually finish off the backend