### PR TITLE
Unit tests for propagator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,9 @@ pub use storage::*;
 pub mod env;
 /// List module for all the list-* subcommands
 pub mod list;
+/// Propagation module with all structs describing the steps
+pub mod propagate;
+
 
 // lift most other pub functions into our libraries main scope
 // this avoids having to type lal::build::build in tests and main.rs
@@ -67,7 +70,6 @@ pub use stash::stash;
 pub use clean::clean;
 pub use query::query;
 pub use publish::publish;
-pub use propagate::propagate;
 
 mod configure;
 mod init;
@@ -83,7 +85,6 @@ mod verify;
 mod stash;
 mod status;
 mod publish;
-mod propagate;
 
 #[cfg(feature = "upgrade")]
 pub use upgrade::upgrade;

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ fn handle_environment_agnostic_cmds(args: &ArgMatches, mf: &Manifest, backend: &
     } else if let Some(a) = args.subcommand_matches("stash") {
         lal::stash(backend, mf, a.value_of("name").unwrap())
     } else if let Some(a) = args.subcommand_matches("propagate") {
-        lal::propagate(mf, a.value_of("component").unwrap(), a.is_present("json"))
+        lal::propagate::print(mf, a.value_of("component").unwrap(), a.is_present("json"))
     } else {
         return ();
     };

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -2,6 +2,7 @@ heylib/INPUT
 heylib/*.o
 heylib/*.a
 heylib/.lal
+prop*/INPUT
 
 helloworld/INPUT
 helloworld/*.o

--- a/tests/prop-base/BUILD
+++ b/tests/prop-base/BUILD
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "pretend build"

--- a/tests/prop-base/manifest.json
+++ b/tests/prop-base/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "prop-base",
+  "environment": "alpine",
+  "supportedEnvironments": [
+    "alpine"
+  ],
+  "components": {
+    "prop-base": {
+      "defaultConfig": "release",
+      "configurations": [
+        "release"
+      ]
+    }
+  },
+  "dependencies": {
+    "prop-mid-1": 1,
+    "prop-mid-2": 1
+  },
+  "devDependencies": {}
+}

--- a/tests/prop-leaf/BUILD
+++ b/tests/prop-leaf/BUILD
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "pretend build"

--- a/tests/prop-leaf/manifest.json
+++ b/tests/prop-leaf/manifest.json
@@ -1,0 +1,17 @@
+{
+  "name": "prop-leaf",
+  "environment": "alpine",
+  "supportedEnvironments": [
+    "alpine"
+  ],
+  "components": {
+    "prop-leaf": {
+      "defaultConfig": "release",
+      "configurations": [
+        "release"
+      ]
+    }
+  },
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/tests/prop-mid-1/BUILD
+++ b/tests/prop-mid-1/BUILD
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "pretend build"

--- a/tests/prop-mid-1/manifest.json
+++ b/tests/prop-mid-1/manifest.json
@@ -1,0 +1,19 @@
+{
+  "name": "prop-mid-1",
+  "environment": "alpine",
+  "supportedEnvironments": [
+    "alpine"
+  ],
+  "components": {
+    "prop-mid-1": {
+      "defaultConfig": "release",
+      "configurations": [
+        "release"
+      ]
+    }
+  },
+  "dependencies": {
+    "prop-leaf": 1
+  },
+  "devDependencies": {}
+}

--- a/tests/prop-mid-2/BUILD
+++ b/tests/prop-mid-2/BUILD
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "pretend build"

--- a/tests/prop-mid-2/manifest.json
+++ b/tests/prop-mid-2/manifest.json
@@ -1,0 +1,19 @@
+{
+  "name": "prop-mid-2",
+  "environment": "alpine",
+  "supportedEnvironments": [
+    "alpine"
+  ],
+  "components": {
+    "prop-mid-2": {
+      "defaultConfig": "release",
+      "configurations": [
+        "release"
+      ]
+    }
+  },
+  "dependencies": {
+    "prop-leaf": 1
+  },
+  "devDependencies": {}
+}

--- a/tests/testmain.rs
+++ b/tests/testmain.rs
@@ -550,7 +550,9 @@ fn check_propagation(leaf: &str) {
         assert!(false, "could propagate leaf to {}", mf.name);
     }
 
-    let rp = lal::propagate::print(&mf, leaf, true);
+    let rpj = lal::propagate::print(&mf, leaf, true);
+    assert!(rpj.is_ok(), "could print propagate json to stdout");
+    let rp = lal::propagate::print(&mf, leaf, false);
     assert!(rp.is_ok(), "could print propagate to stdout");
 
     // print tree for extra coverage of bigger trees


### PR DESCRIPTION
Adds a small fake dependency tree that looks like this:

```sh
prop-base
├─┬ prop-mid-1  (1-alpine) (2017-11-27 23:27:57)
│ └── prop-leaf (1-alpine) (2017-11-27 23:27:03)
└─┬ prop-mid-2  (1-alpine) (2017-11-27 23:28:34)
│ └── prop-leaf (1-alpine) (2017-11-27 23:27:03)
```

then tests that the propagation looks like:

```sh
Assuming prop-leaf has been updated:
Stage 1:
- update [prop-leaf] in prop-mid-1
- update [prop-leaf] in prop-mid-2
Stage 2:
- update [prop-mid-1, prop-mid-2] in prop-base
```