### PR TITLE
Run tests in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,6 @@ dependencies = [
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "serial_test 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha1 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -487,11 +486,6 @@ dependencies = [
 [[package]]
 name = "matches"
 version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "maybe-uninit"
-version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -629,35 +623,11 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "lock_api 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lock_api 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot_core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -690,26 +660,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "proc-macro2"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -889,14 +843,6 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -987,36 +933,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "serial_test"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serial_test_derive 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "sha1"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "smallvec"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "smallvec"
@@ -1027,16 +946,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "syn"
@@ -1177,11 +1086,6 @@ dependencies = [
 [[package]]
 name = "unicode-width"
 version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "unicode-xid"
-version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1335,7 +1239,6 @@ dependencies = [
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum loggerv 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b178879253fab6ddb4ea931e1e6f514d45ce6a53f7fe618a0a8751f43e42e4f1"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
-"checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
@@ -1351,15 +1254,11 @@ dependencies = [
 "checksum openssl-sys 0.9.53 (registry+https://github.com/rust-lang/crates.io-index)" = "465d16ae7fc0e313318f7de5cecf57b2fbe7511fd213978b457e1c96ff46736f"
 "checksum parameterized-macro 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8a01df7a2035840851c9bc9bcf132255a150b7914883e8d6958b3d628b7dd15b"
 "checksum parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc"
-"checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
-"checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 "checksum parking_lot_core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7582838484df45743c8434fbff785e8edf260c28748353d44bc0da32e0ceabf1"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
-"checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
-"checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)" = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
@@ -1380,7 +1279,6 @@ dependencies = [
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum rust-argon2 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ca4eaef519b494d1f2848fc602d18816fed808a981aedf4f1f00ceb7c9d32cf"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
-"checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 "checksum safemem 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 "checksum same-file 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d931a44fdaa43b8637009e7632a02adc4f2b2e0733c08caa4cf00e8da4a117a7"
@@ -1393,13 +1291,9 @@ dependencies = [
 "checksum serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)" = "1217f97ab8e8904b57dd22eb61cde455fa7446a9c1cf43966066da047c1f3702"
 "checksum serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)" = "a8c6faef9a2e64b0064f48570289b4bf8823b7581f1d6157c1b52152306651d0"
 "checksum serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)" = "48c575e0cc52bdd09b47f330f646cf59afc586e9c4e3ccd6fc1f625b8ea1dad7"
-"checksum serial_test 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2b882e1690250abf8655b8a583faf1987cb7e16cd0547fa9b0546ede0f03a445"
-"checksum serial_test_derive 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a3b0af7e5bb94630cf8266333c3902100f6786961c10a36fac3900e1c78d9afc"
 "checksum sha1 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f35e6e47328ec7d599a0adba8233559dc4711d752ba9c4c6078274b8be9d5a77"
-"checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 "checksum smallvec 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ecf3b85f68e8abaa7555aa5abdb1153079387e60b718283d732f03897fcfc86"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-"checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238"
 "checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 "checksum tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)" = "b3196bfbffbba3e57481b6ea32249fbaf590396a52505a2615adbb79d9d826d3"
@@ -1417,7 +1311,6 @@ dependencies = [
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b561e267b2326bb4cebfc0ef9e68355c7abe6c6f522aeac2f5bf95d56c59bdcf"
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
-"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ tar = "0.4.10"
 walkdir = "1.0.7"
 dirs = "2.0.2"
 tempdir = "0.3.7"
-fs_extra = "1.1.0"
 
 [dependencies.indicatif]
 optional = true
@@ -57,5 +56,5 @@ name = "lal"
 path = "src/lib.rs"
 
 [dev-dependencies]
-serial_test = "0.3.1"
+fs_extra = "1.1.0"
 parameterized-macro = "0.1.1"

--- a/src/build.rs
+++ b/src/build.rs
@@ -28,14 +28,17 @@ fn find_valid_build_script(component_dir: &Path) -> LalResult<String> {
     trace!("Using BUILD script found in {}", bpath.display());
     // Need the string to construct a list of argument for docker run
     // lossy convert because paths can somehow contain non-unicode?
-    let build_string = format!("./{}", bpath.strip_prefix(&component_dir).unwrap().to_string_lossy());
+    let build_string = format!(
+        "./{}",
+        bpath.strip_prefix(&component_dir).unwrap().to_string_lossy()
+    );
 
     // presumably we can always get the permissions of a file, right? (inb4 nfs..)
     let mode = bpath.metadata()?.permissions().mode();
     if mode & 0o111 == 0 {
-        return Err(CliError::BuildScriptNotExecutable(build_string.into()));
+        return Err(CliError::BuildScriptNotExecutable(build_string));
     }
-    Ok(build_string.into())
+    Ok(build_string)
 }
 
 
@@ -170,7 +173,9 @@ pub fn build(
         fs::copy(&lockpth, &component_dir.join("./ARTIFACT/lockfile.json"))?;
 
         trace!("Tar up OUTPUT into ARTIFACT/component.tar.gz");
-        let tarpth = component_dir.join("./ARTIFACT").join([component, ".tar.gz".into()].concat());
+        let tarpth = component_dir
+            .join("./ARTIFACT")
+            .join([component, ".tar.gz".into()].concat());
         output::tar(&component_dir, &tarpth)?;
     }
     Ok(())

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -189,8 +189,8 @@ fn non_root_sanity() -> LalResult<()> {
     }
 }
 
-fn create_lal_dir() -> LalResult<PathBuf> {
-    let laldir = config_dir(None);
+fn create_lal_dir(home: Option<&Path>) -> LalResult<PathBuf> {
+    let laldir = config_dir(home);
     if !laldir.is_dir() {
         fs::create_dir(&laldir)?;
     }
@@ -205,8 +205,8 @@ fn create_lal_dir() -> LalResult<PathBuf> {
 ///
 /// A boolean option to discard the output is supplied for tests.
 /// A defaults file must be supplied to seed the new config with defined environments
-pub fn configure(save: bool, interactive: bool, defaults: &str) -> LalResult<Config> {
-    let _ = create_lal_dir()?;
+pub fn configure(save: bool, interactive: bool, defaults: &str, home: Option<&Path>) -> LalResult<Config> {
+    let _ = create_lal_dir(home)?;
 
     for exe in ["tar", "touch", "id", "find", "mkdir", "chmod", "uname"].iter() {
         executable_on_path(exe)?;
@@ -230,10 +230,10 @@ pub fn configure(save: bool, interactive: bool, defaults: &str) -> LalResult<Con
         lal_version_check(&minlal)?;
     }
 
-    let mut cfg = Config::new(def);
+    let mut cfg = Config::new(def, home);
     cfg.interactive = interactive; // need to override default for tests
     if save {
-        cfg.write(false, None)?;
+        cfg.write(false, home)?;
     }
     Ok(cfg)
 }

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -190,7 +190,7 @@ fn non_root_sanity() -> LalResult<()> {
 }
 
 fn create_lal_dir() -> LalResult<PathBuf> {
-    let laldir = config_dir();
+    let laldir = config_dir(None);
     if !laldir.is_dir() {
         fs::create_dir(&laldir)?;
     }
@@ -233,7 +233,7 @@ pub fn configure(save: bool, interactive: bool, defaults: &str) -> LalResult<Con
     let mut cfg = Config::new(def);
     cfg.interactive = interactive; // need to override default for tests
     if save {
-        cfg.write(false)?;
+        cfg.write(false, None)?;
     }
     Ok(cfg)
 }

--- a/src/core/ensure.rs
+++ b/src/core/ensure.rs
@@ -2,13 +2,12 @@ use std::{fs, io, path::Path};
 
 
 /// Ensure a directory exists and is empty
-pub fn ensure_dir_exists_fresh(dir: &str) -> io::Result<()> {
-    let dir = Path::new(dir);
-    if dir.is_dir() {
+pub fn ensure_dir_exists_fresh(dir: &Path) -> io::Result<()> {
+    if dir.exists() {
         // clean it out first
         fs::remove_dir_all(&dir)?;
     }
     fs::create_dir_all(&dir)?;
-    debug!("Ensuring fresh dir: {}", dir.display());
+    debug!("Ensuring fresh dir: {}", &dir.display());
     Ok(())
 }

--- a/src/core/input.rs
+++ b/src/core/input.rs
@@ -12,7 +12,10 @@ struct PartialLock {
     pub version: String,
 }
 fn read_partial_lockfile(component: &str, component_dir: &Path) -> LalResult<PartialLock> {
-    let lock_path = component_dir.join("./INPUT").join(component).join("lockfile.json");
+    let lock_path = component_dir
+        .join("./INPUT")
+        .join(component)
+        .join("lockfile.json");
     if !lock_path.exists() {
         return Err(CliError::MissingLockfile(component.to_string()));
     }

--- a/src/core/input.rs
+++ b/src/core/input.rs
@@ -11,8 +11,8 @@ use super::{CliError, LalResult, Lockfile, Manifest};
 struct PartialLock {
     pub version: String,
 }
-fn read_partial_lockfile(component: &str) -> LalResult<PartialLock> {
-    let lock_path = Path::new("./INPUT").join(component).join("lockfile.json");
+fn read_partial_lockfile(component: &str, component_dir: &Path) -> LalResult<PartialLock> {
+    let lock_path = component_dir.join("./INPUT").join(component).join("lockfile.json");
     if !lock_path.exists() {
         return Err(CliError::MissingLockfile(component.to_string()));
     }
@@ -22,19 +22,19 @@ fn read_partial_lockfile(component: &str) -> LalResult<PartialLock> {
     Ok(serde_json::from_str(&lock_str)?)
 }
 
-pub fn present() -> bool {
-    Path::new("./INPUT").is_dir()
+pub fn present(component_dir: &Path) -> bool {
+    component_dir.join("./INPUT").is_dir()
 }
 
 /// Simple INPUT analyzer for the lockfile generator and `analyze_full`
-pub fn analyze() -> LalResult<BTreeMap<String, String>> {
-    let input = Path::new("./INPUT");
+pub fn analyze(component_dir: &Path) -> LalResult<BTreeMap<String, String>> {
+    let input = component_dir.join("./INPUT");
 
     let mut deps = BTreeMap::new();
     if !input.is_dir() {
         return Ok(deps);
     }
-    let dirs = WalkDir::new("INPUT")
+    let dirs = WalkDir::new(&component_dir.join("INPUT"))
         .min_depth(1)
         .max_depth(1)
         .into_iter()
@@ -42,9 +42,9 @@ pub fn analyze() -> LalResult<BTreeMap<String, String>> {
         .filter(|e| e.path().is_dir());
 
     for d in dirs {
-        let pth = d.path().strip_prefix("INPUT").unwrap();
+        let pth = d.path().strip_prefix(&component_dir.join("INPUT")).unwrap();
         let component = pth.to_str().unwrap();
-        let lck = read_partial_lockfile(component)?;
+        let lck = read_partial_lockfile(component, &component_dir)?;
         deps.insert(component.to_string(), lck.version);
     }
     Ok(deps)
@@ -63,10 +63,10 @@ pub struct InputDependency {
 pub type InputMap = BTreeMap<String, InputDependency>;
 
 /// Helper for `lal::status`
-pub fn analyze_full(manifest: &Manifest) -> LalResult<InputMap> {
-    let input = Path::new("./INPUT");
+pub fn analyze_full(manifest: &Manifest, component_dir: &Path) -> LalResult<InputMap> {
+    let input = component_dir.join("./INPUT");
 
-    let deps = analyze()?;
+    let deps = analyze(&component_dir)?;
     let saved_deps = manifest.all_dependencies();
 
     let mut depmap = InputMap::new();
@@ -111,17 +111,17 @@ pub fn analyze_full(manifest: &Manifest) -> LalResult<InputMap> {
 }
 
 /// Basic part of input verifier - checks that everything is at least present
-pub fn verify_dependencies_present(m: &Manifest) -> LalResult<()> {
+pub fn verify_dependencies_present(component_dir: &Path, m: &Manifest) -> LalResult<()> {
     let mut error = None;
     let mut deps = vec![];
-    let dirs = WalkDir::new("INPUT")
+    let dirs = WalkDir::new(component_dir.join("INPUT"))
         .min_depth(1)
         .max_depth(1)
         .into_iter()
         .filter_map(|e| e.ok())
         .filter(|e| e.path().is_dir());
     for entry in dirs {
-        let pth = entry.path().strip_prefix("INPUT").unwrap();
+        let pth = entry.path().strip_prefix(component_dir.join("INPUT")).unwrap();
         debug!("-> {}", pth.display());
 
         let component = pth.to_str().unwrap();

--- a/src/core/lockfile.rs
+++ b/src/core/lockfile.rs
@@ -91,7 +91,10 @@ impl Lockfile {
 
     // Helper constructor for input populator below
     fn from_input_component(component: &str, component_dir: &Path) -> LalResult<Self> {
-        let lock_path = component_dir.join("./INPUT").join(component).join("lockfile.json");
+        let lock_path = component_dir
+            .join("./INPUT")
+            .join(component)
+            .join("lockfile.json");
         Ok(Lockfile::from_path(&lock_path, component)?)
     }
 

--- a/src/core/lockfile.rs
+++ b/src/core/lockfile.rs
@@ -84,14 +84,14 @@ impl Lockfile {
     }
 
     /// A reader from ARTIFACT directory
-    pub fn release_build() -> LalResult<Self> {
-        let lpath = Path::new("ARTIFACT").join("lockfile.json");
+    pub fn release_build(component_dir: &Path) -> LalResult<Self> {
+        let lpath = component_dir.join("ARTIFACT").join("lockfile.json");
         Ok(Lockfile::from_path(&lpath, "release build")?)
     }
 
     // Helper constructor for input populator below
-    fn from_input_component(component: &str) -> LalResult<Self> {
-        let lock_path = Path::new("./INPUT").join(component).join("lockfile.json");
+    fn from_input_component(component: &str, component_dir: &Path) -> LalResult<Self> {
+        let lock_path = component_dir.join("./INPUT").join(component).join("lockfile.json");
         Ok(Lockfile::from_path(&lock_path, component)?)
     }
 
@@ -99,12 +99,12 @@ impl Lockfile {
     ///
     /// NB: This currently reads all the lockfiles partially in `analyze`,
     /// the re-reads them fully in `read_lockfile_from_component` so can be sped up.
-    pub fn populate_from_input(mut self) -> LalResult<Self> {
+    pub fn populate_from_input(mut self, component_dir: &Path) -> LalResult<Self> {
         debug!("Reading all lockfiles");
-        let deps = input::analyze()?;
+        let deps = input::analyze(&component_dir)?;
         for name in deps.keys() {
             trace!("Populating lockfile with {}", name);
-            let deplock = Lockfile::from_input_component(name)?;
+            let deplock = Lockfile::from_input_component(name, &component_dir)?;
             self.dependencies.insert(name.clone(), deplock);
         }
         Ok(self)

--- a/src/core/manifest.rs
+++ b/src/core/manifest.rs
@@ -129,9 +129,9 @@ impl Manifest {
         deps
     }
 
-    /// Read a manifest file in PWD
-    pub fn read() -> LalResult<Manifest> {
-        Ok(Manifest::read_from(&Path::new(".").to_path_buf())?)
+    /// Read a manifest file in component dir
+    pub fn read(component_dir: &Path) -> LalResult<Manifest> {
+        Ok(Manifest::read_from(&component_dir.to_path_buf())?)
     }
 
     /// Read a manifest file in an arbitrary path

--- a/src/core/output.rs
+++ b/src/core/output.rs
@@ -3,7 +3,7 @@ use std::{path::Path, process::Command};
 use super::{CliError, LalResult};
 
 /// Helper for stash and build
-pub fn tar(tarball: &Path) -> LalResult<()> {
+pub fn tar(component_dir: &Path, tarball: &Path) -> LalResult<()> {
     info!("Taring OUTPUT");
     let mut args: Vec<String> = vec![
         "czf".into(),
@@ -15,7 +15,7 @@ pub fn tar(tarball: &Path) -> LalResult<()> {
     // All links, hidden files, and regular files should go into the tarball.
     let findargs = vec!["OUTPUT/", "-type", "f", "-o", "-type", "l"];
     debug!("find {}", findargs.join(" "));
-    let find_output = Command::new("find").args(&findargs).output()?;
+    let find_output = Command::new("find").args(&findargs).current_dir(&component_dir).output()?;
     let find_str = String::from_utf8_lossy(&find_output.stdout);
 
     // append each file as an arg to the main tar process
@@ -25,7 +25,7 @@ pub fn tar(tarball: &Path) -> LalResult<()> {
 
     // basically `tar czf component.tar.gz --transform.. $(find OUTPUT -type f -o -type l)`:
     debug!("tar {}", args.join(" "));
-    let s = Command::new("tar").args(&args).status()?;
+    let s = Command::new("tar").args(&args).current_dir(&component_dir).status()?;
 
     if !s.success() {
         return Err(CliError::SubprocessFailure(s.code().unwrap_or(1001)));

--- a/src/core/output.rs
+++ b/src/core/output.rs
@@ -15,7 +15,10 @@ pub fn tar(component_dir: &Path, tarball: &Path) -> LalResult<()> {
     // All links, hidden files, and regular files should go into the tarball.
     let findargs = vec!["OUTPUT/", "-type", "f", "-o", "-type", "l"];
     debug!("find {}", findargs.join(" "));
-    let find_output = Command::new("find").args(&findargs).current_dir(&component_dir).output()?;
+    let find_output = Command::new("find")
+        .args(&findargs)
+        .current_dir(&component_dir)
+        .output()?;
     let find_str = String::from_utf8_lossy(&find_output.stdout);
 
     // append each file as an arg to the main tar process
@@ -25,7 +28,10 @@ pub fn tar(component_dir: &Path, tarball: &Path) -> LalResult<()> {
 
     // basically `tar czf component.tar.gz --transform.. $(find OUTPUT -type f -o -type l)`:
     debug!("tar {}", args.join(" "));
-    let s = Command::new("tar").args(&args).current_dir(&component_dir).status()?;
+    let s = Command::new("tar")
+        .args(&args)
+        .current_dir(&component_dir)
+        .status()?;
 
     if !s.success() {
         return Err(CliError::SubprocessFailure(s.code().unwrap_or(1001)));

--- a/src/core/sticky.rs
+++ b/src/core/sticky.rs
@@ -1,6 +1,6 @@
 use serde_json;
 use std::{
-    env, fs,
+    fs,
     io::prelude::{Read, Write},
     path::Path,
 };
@@ -24,8 +24,8 @@ impl StickyOptions {
     }
 
     /// Read and deserialize a StickyOptions from `.lal/opts`
-    pub fn read() -> LalResult<StickyOptions> {
-        let opts_path = Path::new(".lal/opts");
+    pub fn read(component_dir: &Path) -> LalResult<StickyOptions> {
+        let opts_path = component_dir.join(".lal/opts");
         if !opts_path.exists() {
             return Ok(StickyOptions::default()); // everything off
         }
@@ -36,10 +36,9 @@ impl StickyOptions {
     }
 
     /// Overwrite `.lal/opts` with current settings
-    pub fn write(&self) -> LalResult<()> {
-        let pwd = env::current_dir()?;
-        create_lal_subdir(&pwd)?; // create the `.lal` subdir if it's not there already
-        let opts_path = Path::new(".lal/opts");
+    pub fn write(&self, component_dir: &Path) -> LalResult<()> {
+        create_lal_subdir(&component_dir.to_path_buf())?; // create the `.lal` subdir if it's not there already
+        let opts_path = component_dir.join(".lal/opts");
         let encoded = serde_json::to_string_pretty(self)?;
 
         let mut f = fs::File::create(&opts_path)?;
@@ -49,8 +48,8 @@ impl StickyOptions {
     }
 
     /// Delete local `.lal/opts`
-    pub fn delete_local() -> LalResult<()> {
-        let opts_path = Path::new(".lal/opts");
+    pub fn delete_local(component_dir: &Path) -> LalResult<()> {
+        let opts_path = component_dir.join(".lal/opts");
         Ok(fs::remove_file(&opts_path)?)
     }
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,16 +1,16 @@
-use std::{process::Command, vec::Vec};
+use std::{path::Path, process::Command, vec::Vec};
 
 use super::{CliError, Config, Environment, LalResult, StickyOptions};
 
 /// Pull the current environment from docker
-pub fn update(environment: &Environment, env: &str) -> LalResult<()> {
+pub fn update(component_dir: &Path, environment: &Environment, env: &str) -> LalResult<()> {
     info!("Updating {} container", env);
     let args: Vec<String> = vec!["pull".into(), format!("{}", environment)];
 
     match environment {
         Environment::Container(container) => {
             trace!("Docker pull {}", container);
-            let s = Command::new("docker").args(&args).status()?;
+            let s = Command::new("docker").args(&args).current_dir(&component_dir).status()?;
             trace!("Exited docker");
             if !s.success() {
                 return Err(CliError::SubprocessFailure(s.code().unwrap_or(1001)));
@@ -22,19 +22,19 @@ pub fn update(environment: &Environment, env: &str) -> LalResult<()> {
 }
 
 /// Creates and sets the environment in the local .lal/opts file
-pub fn set(opts_: &StickyOptions, cfg: &Config, env: &str) -> LalResult<()> {
+pub fn set(component_dir: &Path, opts_: &StickyOptions, cfg: &Config, env: &str) -> LalResult<()> {
     if !cfg.environments.contains_key(env) {
         return Err(CliError::MissingEnvironment(env.into()));
     }
     // mutate a temporary copy - lal binary is done after this function anyway
     let mut opts = opts_.clone();
     opts.env = Some(env.into());
-    opts.write()?;
+    opts.write(&component_dir)?;
     Ok(())
 }
 
 /// Clears the local .lal/opts file
-pub fn clear() -> LalResult<()> {
-    let _ = StickyOptions::delete_local();
+pub fn clear(component_dir: &Path) -> LalResult<()> {
+    let _ = StickyOptions::delete_local(&component_dir);
     Ok(())
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -10,7 +10,10 @@ pub fn update(component_dir: &Path, environment: &Environment, env: &str) -> Lal
     match environment {
         Environment::Container(container) => {
             trace!("Docker pull {}", container);
-            let s = Command::new("docker").args(&args).current_dir(&component_dir).status()?;
+            let s = Command::new("docker")
+                .args(&args)
+                .current_dir(&component_dir)
+                .status()?;
             trace!("Exited docker");
             if !s.success() {
                 return Err(CliError::SubprocessFailure(s.code().unwrap_or(1001)));

--- a/src/export.rs
+++ b/src/export.rs
@@ -7,7 +7,7 @@ use storage::CachedBackend;
 pub fn export<T: CachedBackend + ?Sized>(
     backend: &T,
     comp: &str,
-    output: Option<&str>,
+    output: &Path,
     _env: Option<&str>,
 ) -> LalResult<()> {
     let env = match _env {
@@ -22,8 +22,7 @@ pub fn export<T: CachedBackend + ?Sized>(
         return Err(CliError::InvalidComponentName(comp.into()));
     }
 
-    let dir = output.unwrap_or(".");
-    info!("Export {} {} to {}", env, comp, dir);
+    info!("Export {} {} to {}", env, comp, output.display());
 
     let mut component_name = comp; // this is only correct if no =version suffix
     let tarname = if comp.contains('=') {
@@ -42,7 +41,7 @@ pub fn export<T: CachedBackend + ?Sized>(
         backend.retrieve_published_component(comp, None, env)?.0
     };
 
-    let dest = Path::new(dir).join(format!("{}.tar.gz", component_name));
+    let dest = output.join(format!("{}.tar.gz", component_name));
     debug!("Copying {:?} to {:?}", tarname, dest);
 
     fs::copy(tarname, dest)?;

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -39,13 +39,15 @@ pub fn fetch<T: CachedBackend + ?Sized>(
     let mut extraneous = vec![]; // stuff we should remove
 
     // figure out what we have already
-    let lf = Lockfile::default().populate_from_input(&component_dir).map_err(|e| {
-        // Guide users a bit if they did something dumb - see #77
-        warn!("Populating INPUT data failed - your INPUT may be corrupt");
-        warn!("This can happen if you CTRL-C during `lal fetch`");
-        warn!("Try to `rm -rf INPUT` and `lal fetch` again.");
-        e
-    })?;
+    let lf = Lockfile::default()
+        .populate_from_input(&component_dir)
+        .map_err(|e| {
+            // Guide users a bit if they did something dumb - see #77
+            warn!("Populating INPUT data failed - your INPUT may be corrupt");
+            warn!("This can happen if you CTRL-C during `lal fetch`");
+            warn!("Try to `rm -rf INPUT` and `lal fetch` again.");
+            e
+        })?;
     // filter out what we already have (being careful to examine env)
     for (name, d) in lf.dependencies {
         // if d.name at d.version in d.envname matches something in deps
@@ -78,12 +80,14 @@ pub fn fetch<T: CachedBackend + ?Sized>(
             })?;
         }
 
-        let _ = backend.unpack_published_component(&component_dir, &k, Some(v), env).map_err(|e| {
-            warn!("Failed to completely install {} ({})", k, e);
-            // likely symlinks inside tarball that are being dodgy
-            // this is why we clean_input
-            err = Some(e);
-        });
+        let _ = backend
+            .unpack_published_component(&component_dir, &k, Some(v), env)
+            .map_err(|e| {
+                warn!("Failed to completely install {} ({})", k, e);
+                // likely symlinks inside tarball that are being dodgy
+                // this is why we clean_input
+                err = Some(e);
+            });
     }
 
     // remove extraneous deps

--- a/src/init.rs
+++ b/src/init.rs
@@ -25,7 +25,12 @@ pub fn init(cfg: &Config, force: bool, component_dir: &Path, env: &str) -> LalRe
     // we are allowed to overwrite or write a new manifest if we are here
     // always create new manifests in new default location
     create_lal_subdir(&component_dir.to_path_buf())?; // create the `.lal` subdir if it's not there already
-    Manifest::new(dirname, env, ManifestLocation::default().as_path(&component_dir.to_path_buf())).write()?;
+    Manifest::new(
+        dirname,
+        env,
+        ManifestLocation::default().as_path(&component_dir.to_path_buf()),
+    )
+    .write()?;
 
     // if the manifest already existed, warn about this now being placed elsewhere
     if let Ok(ManifestLocation::RepoRoot) = mpath {

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,4 +1,4 @@
-use std::env;
+use std::path::{Component, Path};
 
 use super::{CliError, Config, LalResult};
 use core::manifest::*;
@@ -11,22 +11,21 @@ use core::manifest::*;
 ///
 /// The function will not overwrite an existing `manifest.json`,
 /// unless the `force` bool is set.
-pub fn init(cfg: &Config, force: bool, env: &str) -> LalResult<()> {
+pub fn init(cfg: &Config, force: bool, component_dir: &Path, env: &str) -> LalResult<()> {
     cfg.get_environment(env.into())?;
 
-    let pwd = env::current_dir()?;
-    let last_comp = pwd.components().last().unwrap(); // std::path::Component
+    let last_comp: Component = component_dir.components().last().unwrap();
     let dirname = last_comp.as_os_str().to_str().unwrap();
 
-    let mpath = ManifestLocation::identify(&pwd);
+    let mpath = ManifestLocation::identify(&component_dir.to_path_buf());
     if !force && mpath.is_ok() {
         return Err(CliError::ManifestExists);
     }
 
     // we are allowed to overwrite or write a new manifest if we are here
     // always create new manifests in new default location
-    create_lal_subdir(&pwd)?; // create the `.lal` subdir if it's not there already
-    Manifest::new(dirname, env, ManifestLocation::default().as_path(&pwd)).write()?;
+    create_lal_subdir(&component_dir.to_path_buf())?; // create the `.lal` subdir if it's not there already
+    Manifest::new(dirname, env, ManifestLocation::default().as_path(&component_dir.to_path_buf())).write()?;
 
     // if the manifest already existed, warn about this now being placed elsewhere
     if let Ok(ManifestLocation::RepoRoot) = mpath {

--- a/src/main.rs
+++ b/src/main.rs
@@ -553,12 +553,12 @@ fn main() {
     if let Some(a) = args.subcommand_matches("configure") {
         result_exit(
             "configure",
-            lal::configure(true, true, a.value_of("file").unwrap()),
+            lal::configure(true, true, a.value_of("file").unwrap(), None),
         );
     }
 
     // Force config to exists before allowing remaining actions
-    let config = Config::read()
+    let config = Config::read(None)
         .map_err(|e| {
             error!("Configuration error: {}", e);
             println!();

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,12 +35,7 @@ fn handle_manifest_agnostic_cmds(
 ) {
     let res = if let Some(a) = args.subcommand_matches("export") {
         let curdir = current_dir().unwrap();
-        lal::export(
-            backend,
-            a.value_of("component").unwrap(),
-            &curdir,
-            explicit_env,
-        )
+        lal::export(backend, a.value_of("component").unwrap(), &curdir, explicit_env)
     } else if let Some(a) = args.subcommand_matches("query") {
         lal::query(
             backend,
@@ -59,7 +54,12 @@ fn handle_manifest_agnostic_cmds(
 }
 
 // functions that need a manifest, but do not depend on environment values
-fn handle_environment_agnostic_cmds(args: &ArgMatches, component_dir: &Path, mf: &Manifest, backend: &dyn Backend) {
+fn handle_environment_agnostic_cmds(
+    args: &ArgMatches,
+    component_dir: &Path,
+    mf: &Manifest,
+    backend: &dyn Backend,
+) {
     let res = if let Some(a) = args.subcommand_matches("status") {
         lal::status(
             &component_dir,
@@ -82,18 +82,35 @@ fn handle_environment_agnostic_cmds(args: &ArgMatches, component_dir: &Path, mf:
             .unwrap()
             .map(String::from)
             .collect::<Vec<_>>();
-        lal::remove(&component_dir, mf, xs, a.is_present("save"), a.is_present("savedev"))
+        lal::remove(
+            &component_dir,
+            mf,
+            xs,
+            a.is_present("save"),
+            a.is_present("savedev"),
+        )
     } else if let Some(a) = args.subcommand_matches("stash") {
         lal::stash(&component_dir, backend, mf, a.value_of("name").unwrap())
     } else if let Some(a) = args.subcommand_matches("propagate") {
-        lal::propagate::print(&component_dir, mf, a.value_of("component").unwrap(), a.is_present("json"))
+        lal::propagate::print(
+            &component_dir,
+            mf,
+            a.value_of("component").unwrap(),
+            a.is_present("json"),
+        )
     } else {
         return;
     };
     result_exit(args.subcommand_name().unwrap(), res);
 }
 
-fn handle_network_cmds(args: &ArgMatches, component_dir: &Path,  mf: &Manifest, backend: &dyn Backend, env: &str) {
+fn handle_network_cmds(
+    args: &ArgMatches,
+    component_dir: &Path,
+    mf: &Manifest,
+    backend: &dyn Backend,
+    env: &str,
+) {
     let res = if let Some(a) = args.subcommand_matches("update") {
         let xs = a
             .values_of("components")
@@ -110,7 +127,14 @@ fn handle_network_cmds(args: &ArgMatches, component_dir: &Path,  mf: &Manifest, 
             env,
         )
     } else if let Some(a) = args.subcommand_matches("update-all") {
-        lal::update_all(&component_dir, mf, backend, a.is_present("save"), a.is_present("dev"), env)
+        lal::update_all(
+            &component_dir,
+            mf,
+            backend,
+            a.is_present("save"),
+            a.is_present("dev"),
+            env,
+        )
     } else if let Some(a) = args.subcommand_matches("fetch") {
         lal::fetch(&component_dir, mf, backend, a.is_present("core"), env)
     } else {
@@ -119,7 +143,13 @@ fn handle_network_cmds(args: &ArgMatches, component_dir: &Path,  mf: &Manifest, 
     result_exit(args.subcommand_name().unwrap(), res)
 }
 
-fn handle_env_command(args: &ArgMatches, component_dir: &Path, cfg: &Config, env: &str, stickies: &StickyOptions) -> Environment {
+fn handle_env_command(
+    args: &ArgMatches,
+    component_dir: &Path,
+    cfg: &Config,
+    env: &str,
+    stickies: &StickyOptions,
+) -> Environment {
     // lookup associated container from
     let environment = cfg
         .get_environment(env.into())
@@ -183,7 +213,14 @@ fn handle_upgrade(args: &ArgMatches, cfg: &Config) {
 }
 
 
-fn handle_docker_cmds(args: &ArgMatches, component_dir: &Path, mf: &Manifest, cfg: &Config, env: &str, environment: &Environment) {
+fn handle_docker_cmds(
+    args: &ArgMatches,
+    component_dir: &Path,
+    mf: &Manifest,
+    cfg: &Config,
+    env: &str,
+    environment: &Environment,
+) {
     let res = if let Some(a) = args.subcommand_matches("verify") {
         // not really a docker related command, but it needs
         // the resolved env to verify consistent dependency usage
@@ -218,7 +255,14 @@ fn handle_docker_cmds(args: &ArgMatches, component_dir: &Path, mf: &Manifest, cf
             host_networking: a.is_present("net-host"),
             env_vars: values_t!(a.values_of("env-var"), String).unwrap_or_else(|_| vec![]),
         };
-        lal::shell(cfg, environment, &modes, xs, a.is_present("privileged"), &component_dir)
+        lal::shell(
+            cfg,
+            environment,
+            &modes,
+            xs,
+            a.is_present("privileged"),
+            &component_dir,
+        )
     } else if let Some(a) = args.subcommand_matches("run") {
         let xs = if a.is_present("parameters") {
             a.values_of("parameters").unwrap().collect::<Vec<_>>()
@@ -596,7 +640,12 @@ fn main() {
     if let Some(a) = args.subcommand_matches("init") {
         result_exit(
             "init",
-            lal::init(&config, a.is_present("force"), &component_dir, a.value_of("environment").unwrap()),
+            lal::init(
+                &config,
+                a.is_present("force"),
+                &component_dir,
+                a.value_of("environment").unwrap(),
+            ),
         );
     } else if let Some(a) = args.subcommand_matches("clean") {
         let days = a.value_of("days").unwrap().parse().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ extern crate openssl_probe;
 extern crate lal;
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 use lal::*;
-use std::{ops::Deref, process};
+use std::{env::current_dir, ops::Deref, path::Path, process};
 
 fn is_integer(v: String) -> Result<(), String> {
     if v.parse::<u32>().is_ok() {
@@ -29,14 +29,16 @@ fn result_exit<T>(name: &str, x: LalResult<T>) {
 fn handle_manifest_agnostic_cmds(
     args: &ArgMatches,
     cfg: &Config,
+    component_dir: &Path,
     backend: &dyn Backend,
     explicit_env: Option<&str>,
 ) {
     let res = if let Some(a) = args.subcommand_matches("export") {
+        let curdir = current_dir().unwrap();
         lal::export(
             backend,
             a.value_of("component").unwrap(),
-            a.value_of("output"),
+            &curdir,
             explicit_env,
         )
     } else if let Some(a) = args.subcommand_matches("query") {
@@ -47,7 +49,7 @@ fn handle_manifest_agnostic_cmds(
             a.is_present("latest"),
         )
     } else if let Some(a) = args.subcommand_matches("publish") {
-        lal::publish(a.value_of("component").unwrap(), backend)
+        lal::publish(None, &component_dir, a.value_of("component").unwrap(), backend)
     } else if args.subcommand_matches("list-environments").is_some() {
         lal::list::environments(cfg)
     } else {
@@ -57,9 +59,10 @@ fn handle_manifest_agnostic_cmds(
 }
 
 // functions that need a manifest, but do not depend on environment values
-fn handle_environment_agnostic_cmds(args: &ArgMatches, mf: &Manifest, backend: &dyn Backend) {
+fn handle_environment_agnostic_cmds(args: &ArgMatches, component_dir: &Path, mf: &Manifest, backend: &dyn Backend) {
     let res = if let Some(a) = args.subcommand_matches("status") {
         lal::status(
+            &component_dir,
             mf,
             a.is_present("full"),
             a.is_present("origin"),
@@ -79,18 +82,18 @@ fn handle_environment_agnostic_cmds(args: &ArgMatches, mf: &Manifest, backend: &
             .unwrap()
             .map(String::from)
             .collect::<Vec<_>>();
-        lal::remove(mf, xs, a.is_present("save"), a.is_present("savedev"))
+        lal::remove(&component_dir, mf, xs, a.is_present("save"), a.is_present("savedev"))
     } else if let Some(a) = args.subcommand_matches("stash") {
-        lal::stash(backend, mf, a.value_of("name").unwrap())
+        lal::stash(&component_dir, backend, mf, a.value_of("name").unwrap())
     } else if let Some(a) = args.subcommand_matches("propagate") {
-        lal::propagate::print(mf, a.value_of("component").unwrap(), a.is_present("json"))
+        lal::propagate::print(&component_dir, mf, a.value_of("component").unwrap(), a.is_present("json"))
     } else {
         return;
     };
     result_exit(args.subcommand_name().unwrap(), res);
 }
 
-fn handle_network_cmds(args: &ArgMatches, mf: &Manifest, backend: &dyn Backend, env: &str) {
+fn handle_network_cmds(args: &ArgMatches, component_dir: &Path,  mf: &Manifest, backend: &dyn Backend, env: &str) {
     let res = if let Some(a) = args.subcommand_matches("update") {
         let xs = a
             .values_of("components")
@@ -98,6 +101,7 @@ fn handle_network_cmds(args: &ArgMatches, mf: &Manifest, backend: &dyn Backend, 
             .map(String::from)
             .collect::<Vec<_>>();
         lal::update(
+            &component_dir,
             mf,
             backend,
             xs,
@@ -106,16 +110,16 @@ fn handle_network_cmds(args: &ArgMatches, mf: &Manifest, backend: &dyn Backend, 
             env,
         )
     } else if let Some(a) = args.subcommand_matches("update-all") {
-        lal::update_all(mf, backend, a.is_present("save"), a.is_present("dev"), env)
+        lal::update_all(&component_dir, mf, backend, a.is_present("save"), a.is_present("dev"), env)
     } else if let Some(a) = args.subcommand_matches("fetch") {
-        lal::fetch(mf, backend, a.is_present("core"), env)
+        lal::fetch(&component_dir, mf, backend, a.is_present("core"), env)
     } else {
         return; // not a network cmnd
     };
     result_exit(args.subcommand_name().unwrap(), res)
 }
 
-fn handle_env_command(args: &ArgMatches, cfg: &Config, env: &str, stickies: &StickyOptions) -> Environment {
+fn handle_env_command(args: &ArgMatches, component_dir: &Path, cfg: &Config, env: &str, stickies: &StickyOptions) -> Environment {
     // lookup associated container from
     let environment = cfg
         .get_environment(env.into())
@@ -129,17 +133,17 @@ fn handle_env_command(args: &ArgMatches, cfg: &Config, env: &str, stickies: &Sti
     // resolve env updates and sticky options before main subcommands
     if let Some(a) = args.subcommand_matches("env") {
         if a.subcommand_matches("update").is_some() {
-            result_exit("env update", lal::env::update(&environment, env))
+            result_exit("env update", lal::env::update(&component_dir, &environment, env))
         } else if a.subcommand_matches("reset").is_some() {
             // NB: if .lal/opts.env points at an environment not in config
             // reset will fail.. possible to fix, but complects this file too much
             // .lal/opts writes are checked in lal::env::set anyway so this
             // would be purely the users fault for editing it manually
-            result_exit("env clear", lal::env::clear())
+            result_exit("env clear", lal::env::clear(&component_dir))
         } else if let Some(sa) = a.subcommand_matches("set") {
             result_exit(
                 "env override",
-                lal::env::set(stickies, cfg, sa.value_of("environment").unwrap()),
+                lal::env::set(&component_dir, stickies, cfg, sa.value_of("environment").unwrap()),
             )
         } else {
             // just print current environment
@@ -179,11 +183,11 @@ fn handle_upgrade(args: &ArgMatches, cfg: &Config) {
 }
 
 
-fn handle_docker_cmds(args: &ArgMatches, mf: &Manifest, cfg: &Config, env: &str, environment: &Environment) {
+fn handle_docker_cmds(args: &ArgMatches, component_dir: &Path, mf: &Manifest, cfg: &Config, env: &str, environment: &Environment) {
     let res = if let Some(a) = args.subcommand_matches("verify") {
         // not really a docker related command, but it needs
         // the resolved env to verify consistent dependency usage
-        lal::verify(mf, env, a.is_present("simple"))
+        lal::verify(&component_dir, mf, env, a.is_present("simple"))
     } else if let Some(a) = args.subcommand_matches("build") {
         let bopts = BuildOptions {
             name: a.value_of("component").map(String::from),
@@ -201,7 +205,7 @@ fn handle_docker_cmds(args: &ArgMatches, mf: &Manifest, cfg: &Config, env: &str,
             host_networking: a.is_present("net-host"),
             env_vars: values_t!(a.values_of("env-var"), String).unwrap_or_else(|_| vec![]),
         };
-        lal::build(cfg, mf, &bopts, env.into(), modes)
+        lal::build(&component_dir, cfg, mf, &bopts, env.into(), modes)
     } else if let Some(a) = args.subcommand_matches("shell") {
         let xs = if a.is_present("cmd") {
             Some(a.values_of("cmd").unwrap().collect::<Vec<_>>())
@@ -214,7 +218,7 @@ fn handle_docker_cmds(args: &ArgMatches, mf: &Manifest, cfg: &Config, env: &str,
             host_networking: a.is_present("net-host"),
             env_vars: values_t!(a.values_of("env-var"), String).unwrap_or_else(|_| vec![]),
         };
-        lal::shell(cfg, environment, &modes, xs, a.is_present("privileged"))
+        lal::shell(cfg, environment, &modes, xs, a.is_present("privileged"), &component_dir)
     } else if let Some(a) = args.subcommand_matches("run") {
         let xs = if a.is_present("parameters") {
             a.values_of("parameters").unwrap().collect::<Vec<_>>()
@@ -234,6 +238,7 @@ fn handle_docker_cmds(args: &ArgMatches, mf: &Manifest, cfg: &Config, env: &str,
             xs,
             &modes,
             a.is_present("privileged"),
+            &component_dir,
         )
     } else {
         return; // no valid docker related command found
@@ -586,11 +591,12 @@ fn main() {
     #[cfg(feature = "upgrade")]
     handle_upgrade(&args, &config);
 
+    let component_dir = current_dir().unwrap();
     // Allow lal init / clean without manifest existing in PWD
     if let Some(a) = args.subcommand_matches("init") {
         result_exit(
             "init",
-            lal::init(&config, a.is_present("force"), a.value_of("environment").unwrap()),
+            lal::init(&config, a.is_present("force"), &component_dir, a.value_of("environment").unwrap()),
         );
     } else if let Some(a) = args.subcommand_matches("clean") {
         let days = a.value_of("days").unwrap().parse().unwrap();
@@ -598,7 +604,7 @@ fn main() {
     }
 
     // Read .lal/opts if it exists
-    let stickies = StickyOptions::read()
+    let stickies = StickyOptions::read(&component_dir)
         .map_err(|e| {
             // Should not happen unless people are mucking with it manually
             error!("Options error: {}", e);
@@ -618,10 +624,10 @@ fn main() {
             })
             .unwrap();
     }
-    handle_manifest_agnostic_cmds(&args, &config, backend.deref(), explicit_env);
+    handle_manifest_agnostic_cmds(&args, &config, &component_dir, backend.deref(), explicit_env);
 
     // Force manifest to exist before allowing remaining actions
-    let manifest = Manifest::read()
+    let manifest = Manifest::read(&component_dir)
         .map_err(|e| {
             error!("Manifest error: {}", e);
             println!("Ensure manifest.json is valid json or run `lal init`");
@@ -630,7 +636,7 @@ fn main() {
         .unwrap();
 
     // Subcommands that are environment agnostic
-    handle_environment_agnostic_cmds(&args, &manifest, backend.deref());
+    handle_environment_agnostic_cmds(&args, &component_dir, &manifest, backend.deref());
 
     // Force a valid container key configured in manifest and corr. value in config
     // NB: --env overrides sticky env overrides manifest.env
@@ -641,7 +647,7 @@ fn main() {
     } else {
         manifest.environment.clone()
     };
-    let environment = handle_env_command(&args, &config, &env, &stickies);
+    let environment = handle_env_command(&args, &component_dir, &config, &env, &stickies);
 
     // Warn users who are using an unsupported environment
     if !manifest
@@ -658,8 +664,8 @@ fn main() {
     }
 
     // Main subcommands
-    handle_network_cmds(&args, &manifest, backend.deref(), &env);
-    handle_docker_cmds(&args, &manifest, &config, &env, &environment);
+    handle_network_cmds(&args, &component_dir, &manifest, backend.deref(), &env);
+    handle_docker_cmds(&args, &component_dir, &manifest, &config, &env, &environment);
 
     unreachable!("Subcommand valid, but not implemented");
 }

--- a/src/propagate.rs
+++ b/src/propagate.rs
@@ -1,6 +1,7 @@
 use super::{LalResult, Lockfile, Manifest};
 use serde_json;
 use std::collections::BTreeSet;
+use std::path::Path;
 
 
 /// A single update of of a propagation
@@ -80,13 +81,13 @@ pub fn compute(lf: &Lockfile, component: &str) -> LalResult<UpdateSequence> {
 ///
 /// This will produce a set of sequential steps, each set itself being parallelizable.
 /// The resulting update steps can be performed in order to ensure `lal verify` is happy.
-pub fn print(manifest: &Manifest, component: &str, json_output: bool) -> LalResult<()> {
+pub fn print(component_dir: &Path, manifest: &Manifest, component: &str, json_output: bool) -> LalResult<()> {
     debug!("Calculating update path for {}", component);
 
     // TODO: allow taking a custom lockfile to be used outside a repo.
     let lf = Lockfile::default()
         .set_name(&manifest.name)
-        .populate_from_input()?;
+        .populate_from_input(&component_dir)?;
 
     let result = compute(&lf, component)?;
 

--- a/src/propagate.rs
+++ b/src/propagate.rs
@@ -1,7 +1,6 @@
 use super::{LalResult, Lockfile, Manifest};
 use serde_json;
-use std::collections::BTreeSet;
-use std::path::Path;
+use std::{collections::BTreeSet, path::Path};
 
 
 /// A single update of of a propagation

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -8,7 +8,12 @@ use storage::Backend;
 ///
 /// Meant to be done after a `lal build -r <component>`
 /// and requires publish credentials in the local `Config`.
-pub fn publish<T: Backend + ?Sized>(home: Option<&Path>, component_dir: &Path, name: &str, backend: &T) -> LalResult<()> {
+pub fn publish<T: Backend + ?Sized>(
+    home: Option<&Path>,
+    component_dir: &Path,
+    name: &str,
+    backend: &T,
+) -> LalResult<()> {
     let artdir = component_dir.join("./ARTIFACT");
     let tarball = artdir.join(format!("{}.tar.gz", name));
     if !artdir.is_dir() || !tarball.exists() {

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -8,15 +8,15 @@ use storage::Backend;
 ///
 /// Meant to be done after a `lal build -r <component>`
 /// and requires publish credentials in the local `Config`.
-pub fn publish<T: Backend + ?Sized>(name: &str, backend: &T) -> LalResult<()> {
-    let artdir = Path::new("./ARTIFACT");
+pub fn publish<T: Backend + ?Sized>(home: Option<&Path>, component_dir: &Path, name: &str, backend: &T) -> LalResult<()> {
+    let artdir = component_dir.join("./ARTIFACT");
     let tarball = artdir.join(format!("{}.tar.gz", name));
     if !artdir.is_dir() || !tarball.exists() {
         warn!("Missing: {}", tarball.display());
         return Err(CliError::MissingReleaseBuild);
     }
 
-    let lock = Lockfile::release_build()?;
+    let lock = Lockfile::release_build(&component_dir)?;
 
     let version = lock.version.parse::<u32>().map_err(|e| {
         error!("Release build not done --with-version=$BUILD_VERSION");
@@ -32,7 +32,7 @@ pub fn publish<T: Backend + ?Sized>(name: &str, backend: &T) -> LalResult<()> {
     let envname = lock.envname;
 
     info!("Publishing {}={} to {}", name, version, envname);
-    backend.publish_artifact(name, version, &envname)?;
+    backend.publish_artifact(home, &component_dir, name, version, &envname)?;
 
     Ok(())
 }

--- a/src/remove.rs
+++ b/src/remove.rs
@@ -9,7 +9,13 @@ use super::{CliError, LalResult, Manifest};
 ///
 /// If one of `save` or `savedev` was set, `manifest.json` is also updated to remove
 /// the specified components from the corresponding dictionary.
-pub fn remove(component_dir: &Path, manifest: &Manifest, xs: Vec<String>, save: bool, savedev: bool) -> LalResult<()> {
+pub fn remove(
+    component_dir: &Path,
+    manifest: &Manifest,
+    xs: Vec<String>,
+    save: bool,
+    savedev: bool,
+) -> LalResult<()> {
     debug!("Removing dependencies {:?}", xs);
 
     // remove entries in xs from manifest.

--- a/src/remove.rs
+++ b/src/remove.rs
@@ -9,7 +9,7 @@ use super::{CliError, LalResult, Manifest};
 ///
 /// If one of `save` or `savedev` was set, `manifest.json` is also updated to remove
 /// the specified components from the corresponding dictionary.
-pub fn remove(manifest: &Manifest, xs: Vec<String>, save: bool, savedev: bool) -> LalResult<()> {
+pub fn remove(component_dir: &Path, manifest: &Manifest, xs: Vec<String>, save: bool, savedev: bool) -> LalResult<()> {
     debug!("Removing dependencies {:?}", xs);
 
     // remove entries in xs from manifest.
@@ -44,12 +44,12 @@ pub fn remove(manifest: &Manifest, xs: Vec<String>, save: bool, savedev: bool) -
     }
 
     // delete the folder (ignore if the folder does not exist)
-    let input = Path::new("./INPUT");
+    let input = component_dir.join("./INPUT");
     if !input.is_dir() {
         return Ok(());
     }
     for component in xs {
-        let pth = Path::new(&input).join(&component);
+        let pth = input.join(&component);
         if pth.is_dir() {
             debug!("Deleting INPUT/{}", component);
             fs::remove_dir_all(&pth)?;

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,4 +1,4 @@
-use std::{env, path::Path, process::Command, vec::Vec};
+use std::{path::Path, process::Command, vec::Vec};
 
 use super::{CliError, Config, Container, Environment, LalResult};
 
@@ -170,20 +170,11 @@ pub fn run(
     command: Vec<String>,
     flags: &DockerRunFlags,
     modes: &ShellModes,
+    component_dir: &Path
 ) -> LalResult<()> {
     match environment {
-        Environment::Container(container) => docker_run(&cfg, &container, command, &flags, &modes),
-
-        Environment::None => {
-            let mut command = command.clone();
-            let exe = command.remove(0);
-            let s = Command::new(exe).args(command).status()?;
-            if !s.success() {
-                return Err(CliError::SubprocessFailure(s.code().unwrap_or(1001)));
-            }
-
-            Ok(())
-        }
+        Environment::Container(container) => docker_run(&cfg, &container, command, &flags, &modes, &component_dir),
+        Environment::None => native_run(command, &component_dir),
     }
 }
 
@@ -198,10 +189,11 @@ pub fn docker_run(
     command: Vec<String>,
     flags: &DockerRunFlags,
     modes: &ShellModes,
+    component_dir: &Path,
 ) -> LalResult<()> {
     let mut modified_container_option: Option<Container> = None;
 
-    trace!("Performing docker permission sanity check");
+    debug!("Performing docker permission sanity check");
     if let Err(e) = permission_sanity_check() {
         match e {
             CliError::DockerPermissionSafety(_, u, g) => {
@@ -224,14 +216,13 @@ pub fn docker_run(
     // Shadow container here
     let container = modified_container_option.as_ref().unwrap_or(container);
 
-    trace!("Finding home and cwd");
+    debug!("Finding home and cwd");
     let home = dirs::home_dir().unwrap(); // crash if no $HOME
-    let pwd = env::current_dir().unwrap();
 
     // construct arguments vector
     let mut args: Vec<String> = vec!["run".into(), "--rm".into()];
     for mount in cfg.mounts.clone() {
-        trace!(" - mounting {}", mount.src);
+        debug!(" - mounting {}", mount.src);
         args.push("-v".into());
         let mnt = format!(
             "{}:{}{}",
@@ -241,9 +232,9 @@ pub fn docker_run(
         );
         args.push(mnt);
     }
-    trace!(" - mounting {}", pwd.display());
+    debug!(" - mounting {}", &component_dir.display());
     args.push("-v".into());
-    args.push(format!("{}:/home/lal/volume", pwd.display()));
+    args.push(format!("{}:/home/lal/volume", &component_dir.display()));
 
     // X11 forwarding
     if modes.x11_forwarding {
@@ -300,9 +291,9 @@ pub fn docker_run(
         }
         println!();
     } else {
-        trace!("Entering docker");
-        let s = Command::new("docker").args(&args).status()?;
-        trace!("Exited docker");
+        debug!("Entering docker");
+        let s = Command::new("docker").args(&args).current_dir(&component_dir).status()?;
+        debug!("Exited docker");
         if !s.success() {
             return Err(CliError::SubprocessFailure(s.code().unwrap_or(1001)));
         }
@@ -311,10 +302,11 @@ pub fn docker_run(
 }
 
 /// Runs an arbitrary command natively, without containerization
-pub fn native_run(mut command: Vec<String>) -> LalResult<()> {
+pub fn native_run(mut command: Vec<String>, component_dir: &Path) -> LalResult<()> {
     let cmd = command.remove(0);
     let mut script_cmd = Command::new(cmd);
-    let s = script_cmd.args(command).status()?;
+    script_cmd.args(command).current_dir(&component_dir);
+    let s = script_cmd.status()?;
 
     if !s.success() {
         return Err(CliError::SubprocessFailure(s.code().unwrap_or(1001)));
@@ -347,6 +339,7 @@ pub fn shell(
     modes: &ShellModes,
     cmd: Option<Vec<&str>>,
     privileged: bool,
+    component_dir: &Path,
 ) -> LalResult<()> {
     let flags = DockerRunFlags {
         interactive: cmd.is_none() || cfg.interactive,
@@ -366,14 +359,14 @@ pub fn shell(
                 info!("Entering {}", container);
             }
 
-            docker_run(cfg, container, command, &flags, modes)
+            docker_run(cfg, container, command, &flags, modes, &component_dir)
         }
         Environment::None => {
             if command.is_empty() {
                 command.push("bash".into());
             }
 
-            native_run(command)
+            native_run(command, &component_dir)
         }
     }
 }
@@ -389,9 +382,11 @@ pub fn script(
     args: Vec<&str>,
     modes: &ShellModes,
     privileged: bool,
+    component_dir: &Path,
 ) -> LalResult<()> {
-    let pth = Path::new(".").join(".lal").join("scripts").join(&name);
-    if !pth.exists() {
+    let pth = Path::new(".lal").join("scripts").join(&name);
+    debug!("pth: {}", &pth.display());
+    if !component_dir.join(&pth).exists() {
         return Err(CliError::MissingScript(name.into()));
     }
 
@@ -399,9 +394,10 @@ pub fn script(
     let command = vec![
         "bash".into(),
         "-c".into(),
-        format!("source {}; main {}", pth.display(), args.join(" ")),
+        format!("source {}; main {}", &pth.display(), args.join(" ")),
     ];
 
+    debug!("script command: {:?}", command);
     match environment {
         Environment::Container(container) => {
             let flags = DockerRunFlags {
@@ -409,8 +405,8 @@ pub fn script(
                 privileged,
             };
 
-            Ok(docker_run(cfg, container, command, &flags, modes)?)
+            Ok(docker_run(cfg, container, command, &flags, modes, &component_dir)?)
         }
-        Environment::None => native_run(command),
+        Environment::None => native_run(command, &component_dir),
     }
 }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -170,10 +170,12 @@ pub fn run(
     command: Vec<String>,
     flags: &DockerRunFlags,
     modes: &ShellModes,
-    component_dir: &Path
+    component_dir: &Path,
 ) -> LalResult<()> {
     match environment {
-        Environment::Container(container) => docker_run(&cfg, &container, command, &flags, &modes, &component_dir),
+        Environment::Container(container) => {
+            docker_run(&cfg, &container, command, &flags, &modes, &component_dir)
+        }
         Environment::None => native_run(command, &component_dir),
     }
 }
@@ -292,7 +294,10 @@ pub fn docker_run(
         println!();
     } else {
         debug!("Entering docker");
-        let s = Command::new("docker").args(&args).current_dir(&component_dir).status()?;
+        let s = Command::new("docker")
+            .args(&args)
+            .current_dir(&component_dir)
+            .status()?;
         debug!("Exited docker");
         if !s.success() {
             return Err(CliError::SubprocessFailure(s.code().unwrap_or(1001)));
@@ -405,7 +410,14 @@ pub fn script(
                 privileged,
             };
 
-            Ok(docker_run(cfg, container, command, &flags, modes, &component_dir)?)
+            Ok(docker_run(
+                cfg,
+                container,
+                command,
+                &flags,
+                modes,
+                &component_dir,
+            )?)
         }
         Environment::None => native_run(command, &component_dir),
     }

--- a/src/stash.rs
+++ b/src/stash.rs
@@ -10,7 +10,12 @@ use storage::CachedBackend;
 /// then copies this to `~/.lal/cache/stash/${name}/`.
 ///
 /// This file can then be installed via `update` using a component=${name} argument.
-pub fn stash<T: CachedBackend + ?Sized>(component_dir: &Path, backend: &T, mf: &Manifest, name: &str) -> LalResult<()> {
+pub fn stash<T: CachedBackend + ?Sized>(
+    component_dir: &Path,
+    backend: &T,
+    mf: &Manifest,
+    name: &str,
+) -> LalResult<()> {
     info!("Stashing OUTPUT into cache under {}/{}", mf.name, name);
     // sanity: verify name does NOT parse as a u32
     if let Ok(n) = name.parse::<u32>() {

--- a/src/stash.rs
+++ b/src/stash.rs
@@ -10,14 +10,14 @@ use storage::CachedBackend;
 /// then copies this to `~/.lal/cache/stash/${name}/`.
 ///
 /// This file can then be installed via `update` using a component=${name} argument.
-pub fn stash<T: CachedBackend + ?Sized>(backend: &T, mf: &Manifest, name: &str) -> LalResult<()> {
+pub fn stash<T: CachedBackend + ?Sized>(component_dir: &Path, backend: &T, mf: &Manifest, name: &str) -> LalResult<()> {
     info!("Stashing OUTPUT into cache under {}/{}", mf.name, name);
     // sanity: verify name does NOT parse as a u32
     if let Ok(n) = name.parse::<u32>() {
         return Err(CliError::InvalidStashName(n));
     }
 
-    let outputdir = Path::new("./OUTPUT");
+    let outputdir = component_dir.join("./OUTPUT");
     if !outputdir.is_dir() {
         return Err(CliError::MissingBuild);
     }
@@ -27,13 +27,13 @@ pub fn stash<T: CachedBackend + ?Sized>(backend: &T, mf: &Manifest, name: &str) 
     // rather than the ugly colony default of "EXPERIMENTAL-${hex}"
     // stashed builds are only used locally so this allows easier inspection
     // full version list is available in `lal ls -f`
-    let lf_path = Path::new("OUTPUT").join("lockfile.json");
+    let lf_path = component_dir.join("OUTPUT").join("lockfile.json");
     let mut lf = Lockfile::from_path(&lf_path, &mf.name)?;
     lf.version = name.to_string();
     lf.write(&lf_path)?;
 
     // main operation:
-    backend.stash_output(&mf.name, name)?;
+    backend.stash_output(&component_dir, &mf.name, name)?;
 
     Ok(())
 }

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,6 +1,7 @@
 use super::{CliError, LalResult, Lockfile, Manifest};
 use ansi_term::{ANSIString, Colour};
 use core::input;
+use std::path::Path;
 
 fn version_string(lf: Option<&Lockfile>, show_ver: bool, show_time: bool) -> ANSIString<'static> {
     if let Some(lock) = lf {
@@ -76,13 +77,13 @@ fn status_recurse(
 /// from lockfile data.
 ///
 /// It is not intended as a verifier, but will nevertheless produce a summary at the end.
-pub fn status(manifest: &Manifest, full: bool, show_ver: bool, show_time: bool) -> LalResult<()> {
+pub fn status(component_dir: &Path, manifest: &Manifest, full: bool, show_ver: bool, show_time: bool) -> LalResult<()> {
     let mut error = None;
 
-    let lf = Lockfile::default().populate_from_input()?;
+    let lf = Lockfile::default().populate_from_input(&component_dir)?;
 
     println!("{}", manifest.name);
-    let deps = input::analyze_full(manifest)?;
+    let deps = input::analyze_full(manifest, &component_dir)?;
     let len = deps.len();
     for (i, (d, dep)) in deps.iter().enumerate() {
         let notes = if dep.missing && !dep.development {

--- a/src/status.rs
+++ b/src/status.rs
@@ -77,7 +77,13 @@ fn status_recurse(
 /// from lockfile data.
 ///
 /// It is not intended as a verifier, but will nevertheless produce a summary at the end.
-pub fn status(component_dir: &Path, manifest: &Manifest, full: bool, show_ver: bool, show_time: bool) -> LalResult<()> {
+pub fn status(
+    component_dir: &Path,
+    manifest: &Manifest,
+    full: bool,
+    show_ver: bool,
+    show_time: bool,
+) -> LalResult<()> {
     let mut error = None;
 
     let lf = Lockfile::default().populate_from_input(&component_dir)?;

--- a/src/storage/artifactory.rs
+++ b/src/storage/artifactory.rs
@@ -367,10 +367,10 @@ impl Backend for ArtifactoryBackend {
         get_tarball_uri(&self.config, name, version, loc)
     }
 
-    fn publish_artifact(&self, name: &str, version: u32, env: &str) -> LalResult<()> {
+    fn publish_artifact(&self, _home: Option<&Path>, component_dir: &Path, name: &str, version: u32, env: &str) -> LalResult<()> {
         // this fn basically assumes all the sanity checks have been performed
         // files must exist and lockfile must be sensible
-        let artdir = Path::new("./ARTIFACT");
+        let artdir = component_dir.join("./ARTIFACT");
         let tarball = artdir.join(format!("{}.tar.gz", name));
         let lockfile = artdir.join("lockfile.json");
 

--- a/src/storage/artifactory.rs
+++ b/src/storage/artifactory.rs
@@ -367,7 +367,14 @@ impl Backend for ArtifactoryBackend {
         get_tarball_uri(&self.config, name, version, loc)
     }
 
-    fn publish_artifact(&self, _home: Option<&Path>, component_dir: &Path, name: &str, version: u32, env: &str) -> LalResult<()> {
+    fn publish_artifact(
+        &self,
+        _home: Option<&Path>,
+        component_dir: &Path,
+        name: &str,
+        version: u32,
+        env: &str,
+    ) -> LalResult<()> {
         // this fn basically assumes all the sanity checks have been performed
         // files must exist and lockfile must be sensible
         let artdir = component_dir.join("./ARTIFACT");

--- a/src/storage/download.rs
+++ b/src/storage/download.rs
@@ -185,7 +185,10 @@ where
 
         // Copy the lockfile there for users inspecting the stashed folder
         // NB: this is not really needed, as it's included in the tarball anyway
-        fs::copy(&component_dir.join("OUTPUT/lockfile.json"), destdir.join("lockfile.json"))?;
+        fs::copy(
+            &component_dir.join("OUTPUT/lockfile.json"),
+            destdir.join("lockfile.json"),
+        )?;
         Ok(())
     }
 }

--- a/src/storage/local.rs
+++ b/src/storage/local.rs
@@ -48,7 +48,7 @@ impl LocalBackend {
 impl Backend for LocalBackend {
     fn get_versions(&self, name: &str, loc: &str) -> LalResult<Vec<u32>> {
         let tar_dir = format!("{}/environments/{}/{}/", self.cache, loc, name);
-        let dentries = fs::read_dir(config_dir().join(tar_dir));
+        let dentries = fs::read_dir(config_dir(None).join(tar_dir));
         let mut versions = vec![];
         for entry in dentries? {
             let path = entry?;
@@ -107,12 +107,12 @@ impl Backend for LocalBackend {
             self.cache, env, name, version
         );
 
-        if let Some(full_tar_dir) = config_dir().join(tar_dir).to_str() {
+        if let Some(full_tar_dir) = config_dir(None).join(tar_dir).to_str() {
             ensure_dir_exists_fresh(full_tar_dir)?;
         }
 
-        fs::copy(tarball, config_dir().join(tar_path))?;
-        fs::copy(lockfile, config_dir().join(lock_path))?;
+        fs::copy(tarball, config_dir(None).join(tar_path))?;
+        fs::copy(lockfile, config_dir(None).join(lock_path))?;
 
         Ok(())
     }

--- a/src/storage/local.rs
+++ b/src/storage/local.rs
@@ -89,7 +89,14 @@ impl Backend for LocalBackend {
         })
     }
 
-    fn publish_artifact(&self, home: Option<&Path>, component_dir: &Path, name: &str, version: u32, env: &str) -> LalResult<()> {
+    fn publish_artifact(
+        &self,
+        home: Option<&Path>,
+        component_dir: &Path,
+        name: &str,
+        version: u32,
+        env: &str,
+    ) -> LalResult<()> {
         // this fn basically assumes all the sanity checks have been performed
         // files must exist and lockfile must be sensible
         let artifactdir = component_dir.join("./ARTIFACT");

--- a/src/storage/local.rs
+++ b/src/storage/local.rs
@@ -89,10 +89,10 @@ impl Backend for LocalBackend {
         })
     }
 
-    fn publish_artifact(&self, name: &str, version: u32, env: &str) -> LalResult<()> {
+    fn publish_artifact(&self, home: Option<&Path>, component_dir: &Path, name: &str, version: u32, env: &str) -> LalResult<()> {
         // this fn basically assumes all the sanity checks have been performed
         // files must exist and lockfile must be sensible
-        let artifactdir = Path::new("./ARTIFACT");
+        let artifactdir = component_dir.join("./ARTIFACT");
         let tarball = artifactdir.join(format!("{}.tar.gz", name));
         let lockfile = artifactdir.join("lockfile.json");
 
@@ -107,12 +107,11 @@ impl Backend for LocalBackend {
             self.cache, env, name, version
         );
 
-        if let Some(full_tar_dir) = config_dir(None).join(tar_dir).to_str() {
-            ensure_dir_exists_fresh(full_tar_dir)?;
-        }
+        let full_tar_dir = config_dir(home).join(tar_dir);
+        ensure_dir_exists_fresh(&full_tar_dir)?;
 
-        fs::copy(tarball, config_dir(None).join(tar_path))?;
-        fs::copy(lockfile, config_dir(None).join(lock_path))?;
+        fs::copy(tarball, config_dir(home).join(tar_path))?;
+        fs::copy(lockfile, config_dir(home).join(lock_path))?;
 
         Ok(())
     }

--- a/src/storage/traits.rs
+++ b/src/storage/traits.rs
@@ -59,7 +59,14 @@ pub trait Backend {
     /// Publish a release build's ARTIFACT to a specific location
     ///
     /// This will publish everything inside the ARTIFACT dir created by `lal build -r`
-    fn publish_artifact(&self, home: Option<&Path>, component_dir: &Path, name: &str, version: u32, env: &str) -> LalResult<()>;
+    fn publish_artifact(
+        &self,
+        home: Option<&Path>,
+        component_dir: &Path,
+        name: &str,
+        version: u32,
+        env: &str,
+    ) -> LalResult<()>;
 
     /// Raw fetch of location to a destination
     ///
@@ -91,8 +98,13 @@ pub trait CachedBackend {
     fn retrieve_stashed_component(&self, name: &str, code: &str) -> LalResult<PathBuf>;
 
     /// Retrieve and unpack a cached component in INPUT
-    fn unpack_published_component(&self, component_dir: &Path, name: &str, version: Option<u32>, env: &str)
-        -> LalResult<Component>;
+    fn unpack_published_component(
+        &self,
+        component_dir: &Path,
+        name: &str,
+        version: Option<u32>,
+        env: &str,
+    ) -> LalResult<Component>;
 
     /// Retrieve and unpack a stashed component to INPUT
     fn unpack_stashed_component(&self, component_dir: &Path, name: &str, code: &str) -> LalResult<()>;

--- a/src/storage/traits.rs
+++ b/src/storage/traits.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use super::{ArtifactoryConfig, LocalConfig};
 use core::LalResult;
@@ -59,7 +59,7 @@ pub trait Backend {
     /// Publish a release build's ARTIFACT to a specific location
     ///
     /// This will publish everything inside the ARTIFACT dir created by `lal build -r`
-    fn publish_artifact(&self, name: &str, version: u32, env: &str) -> LalResult<()>;
+    fn publish_artifact(&self, home: Option<&Path>, component_dir: &Path, name: &str, version: u32, env: &str) -> LalResult<()>;
 
     /// Raw fetch of location to a destination
     ///
@@ -91,12 +91,12 @@ pub trait CachedBackend {
     fn retrieve_stashed_component(&self, name: &str, code: &str) -> LalResult<PathBuf>;
 
     /// Retrieve and unpack a cached component in INPUT
-    fn unpack_published_component(&self, name: &str, version: Option<u32>, env: &str)
+    fn unpack_published_component(&self, component_dir: &Path, name: &str, version: Option<u32>, env: &str)
         -> LalResult<Component>;
 
     /// Retrieve and unpack a stashed component to INPUT
-    fn unpack_stashed_component(&self, name: &str, code: &str) -> LalResult<()>;
+    fn unpack_stashed_component(&self, component_dir: &Path, name: &str, code: &str) -> LalResult<()>;
 
     /// Add a stashed component from a folder
-    fn stash_output(&self, name: &str, code: &str) -> LalResult<()>;
+    fn stash_output(&self, component_dir: &Path, name: &str, code: &str) -> LalResult<()>;
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,6 +1,6 @@
 use super::{CliError, LalResult, Manifest};
-use storage::CachedBackend;
 use std::path::Path;
+use storage::CachedBackend;
 
 /// Update specific dependencies outside the manifest
 ///
@@ -42,10 +42,12 @@ pub fn update<T: CachedBackend + ?Sized>(
             } else {
                 // fetch from stash - this does not go into `updated` it it succeeds
                 // because we wont and cannot save stashed versions in the manifest
-                let _ = backend.unpack_stashed_component(&component_dir, pair[0], pair[1]).map_err(|e| {
-                    warn!("Failed to update {} from stash ({})", pair[0], e);
-                    error = Some(e);
-                });
+                let _ = backend
+                    .unpack_stashed_component(&component_dir, pair[0], pair[1])
+                    .map_err(|e| {
+                        warn!("Failed to update {} from stash ({})", pair[0], e);
+                        error = Some(e);
+                    });
             }
         } else {
             if &comp.to_lowercase() != comp {
@@ -129,5 +131,13 @@ pub fn update_all<T: CachedBackend + ?Sized>(
     } else {
         manifest.dependencies.keys().cloned().collect()
     };
-    update(&component_dir, manifest, backend, deps, save && !dev, save && dev, env)
+    update(
+        &component_dir,
+        manifest,
+        backend,
+        deps,
+        save && !dev,
+        save && dev,
+        env,
+    )
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,5 +1,6 @@
 use super::{CliError, LalResult, Manifest};
 use storage::CachedBackend;
+use std::path::Path;
 
 /// Update specific dependencies outside the manifest
 ///
@@ -10,6 +11,7 @@ use storage::CachedBackend;
 /// If one `save` or `savedev` was set, the fetched versions are also updated in the
 /// manifest. This provides an easy way to not have to deal with strict JSON manually.
 pub fn update<T: CachedBackend + ?Sized>(
+    component_dir: &Path,
     manifest: &Manifest,
     backend: &T,
     components: Vec<String>,
@@ -30,7 +32,7 @@ pub fn update<T: CachedBackend + ?Sized>(
                     return Err(CliError::InvalidComponentName(pair[0].into()));
                 }
                 // standard fetch with an integer version
-                match backend.unpack_published_component(pair[0], Some(n), env) {
+                match backend.unpack_published_component(&component_dir, pair[0], Some(n), env) {
                     Ok(c) => updated.push(c),
                     Err(e) => {
                         warn!("Failed to update {} ({})", pair[0], e);
@@ -40,7 +42,7 @@ pub fn update<T: CachedBackend + ?Sized>(
             } else {
                 // fetch from stash - this does not go into `updated` it it succeeds
                 // because we wont and cannot save stashed versions in the manifest
-                let _ = backend.unpack_stashed_component(pair[0], pair[1]).map_err(|e| {
+                let _ = backend.unpack_stashed_component(&component_dir, pair[0], pair[1]).map_err(|e| {
                     warn!("Failed to update {} from stash ({})", pair[0], e);
                     error = Some(e);
                 });
@@ -61,7 +63,7 @@ pub fn update<T: CachedBackend + ?Sized>(
                 .ok_or_else(|| CliError::NoIntersectedVersion(comp.clone()))?;
             info!("Fetch {} {}={}", env, comp, ver);
 
-            match backend.unpack_published_component(comp, Some(ver), env) {
+            match backend.unpack_published_component(&component_dir, comp, Some(ver), env) {
                 Ok(c) => updated.push(c),
                 Err(e) => {
                     warn!("Failed to update {} ({})", &comp, e);
@@ -115,6 +117,7 @@ pub fn update<T: CachedBackend + ?Sized>(
 /// If the save flag is set, then the manifest will be updated correctly.
 /// I.e. dev updates will update only the dev portions of the manifest.
 pub fn update_all<T: CachedBackend + ?Sized>(
+    component_dir: &Path,
     manifest: &Manifest,
     backend: &T,
     save: bool,
@@ -126,5 +129,5 @@ pub fn update_all<T: CachedBackend + ?Sized>(
     } else {
         manifest.dependencies.keys().cloned().collect()
     };
-    update(manifest, backend, deps, save && !dev, save && dev, env)
+    update(&component_dir, manifest, backend, deps, save && !dev, save && dev, env)
 }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1,6 +1,6 @@
 use super::{LalResult, Lockfile, Manifest};
-use std::path::Path;
 use input;
+use std::path::Path;
 
 /// Verifies that `./INPUT` satisfies all strictness conditions.
 ///

--- a/tests/testmain.rs
+++ b/tests/testmain.rs
@@ -339,7 +339,7 @@ fn test_export_checks(env_name: &str) {
     info!("ok fetch_release_build_and_publish helloworld");
 
     // back to tmpdir to test export and clean
-    assert!(env::set_current_dir(config_dir()).is_ok());
+    assert!(env::set_current_dir(config_dir(None)).is_ok());
     export_check(&env_name, &state.backend);
     info!("ok export_check");
 }
@@ -363,7 +363,7 @@ fn test_query_check(env_name: &str) {
     info!("ok fetch_release_build_and_publish helloworld");
 
     // back to tmpdir to test export and clean
-    assert!(env::set_current_dir(config_dir()).is_ok());
+    assert!(env::set_current_dir(config_dir(None)).is_ok());
 
     query_check(&env_name, &state.backend);
     info!("ok query_check");
@@ -388,7 +388,7 @@ fn test_clean_check(env_name: &str) {
     info!("ok fetch_release_build_and_publish helloworld");
 
     // back to tmpdir to test export and clean
-    assert!(env::set_current_dir(config_dir()).is_ok());
+    assert!(env::set_current_dir(config_dir(None)).is_ok());
 
     clean_check();
     info!("ok clean_check");
@@ -467,7 +467,7 @@ fn test_propagations(env_name: &str) {
 }
 
 fn kill_laldir() {
-    let laldir = config_dir();
+    let laldir = config_dir(None);
     if laldir.is_dir() {
         fs::remove_dir_all(&laldir).unwrap();
     }
@@ -583,7 +583,7 @@ fn init_force(env_name: &str) {
 // Tests need to be run in a directory with a manifest
 // and ~/.lal + config must exist
 fn has_config_and_manifest() {
-    let ldir = config_dir();
+    let ldir = config_dir(None);
     assert!(ldir.is_dir(), "have laldir");
 
     let cfg = Config::read();

--- a/tests/testmain.rs
+++ b/tests/testmain.rs
@@ -3,7 +3,6 @@ extern crate lal;
 extern crate fs_extra;
 #[macro_use] extern crate log;
 extern crate loggerv;
-#[macro_use] extern crate serial_test;
 extern crate parameterized_macro;
 extern crate tempdir;
 extern crate walkdir;
@@ -54,15 +53,7 @@ fn setup() -> TestState {
     // Do all lal tests in a tempdir as it messes with the manifest
     let tempdir = TempDir::new("laltest").unwrap();
 
-    // dump config and artifacts under the current temp directory
-    let configdir = tempdir.path();
-    env::set_var("LAL_CONFIG_HOME", configdir);
-
-    // Requires "LAL_CONFIG_HOME" set before calling
-    let backend = configure_local_backend(&demo_config);
-
-    // Run tests (starting) from their own directory
-    assert!(env::set_current_dir(tempdir.path().clone()).is_ok());
+    let backend = configure_local_backend(&demo_config, &tempdir.path());
 
     TestState {
         backend,
@@ -73,18 +64,17 @@ fn setup() -> TestState {
 
 // Copies the component to a temporary location for this test
 // and sets the working directory to that location
-fn chdir_to_component(component: &str, state: &TestState) {
+fn clone_component_dir(component: &str, state: &TestState) -> PathBuf {
     let copy_options = CopyOptions::new();
 
     let from = state.testdir.join(component);
     let to = state.tempdir.path().join(component);
 
     copy(&from, state.tempdir.path(), &copy_options).expect("copy component to tempdir");
-    assert!(env::set_current_dir(&to).is_ok());
+    return to;
 }
 
 #[parameterized(env_name = {"default", "alpine"})]
-#[serial]
 fn test_configure_backend(env_name: &str) {
     let state = setup();
     if !cfg!(feature = "docker") && env_name == "alpine" {
@@ -93,12 +83,11 @@ fn test_configure_backend(env_name: &str) {
 
     assert_eq!(
         fs::canonicalize(Path::new(&state.backend.get_cache_dir())).unwrap(),
-        fs::canonicalize(Path::new("./.lal/cache")).unwrap(),
+        fs::canonicalize(&state.tempdir.path().join(".lal/cache")).unwrap(),
     );
 }
 
 #[parameterized(env_name = {"default", "alpine"})]
-#[serial]
 fn test_heylib_echo(env_name: &str) {
     let state = setup();
     if !cfg!(feature = "docker") && env_name == "alpine" {
@@ -106,14 +95,13 @@ fn test_heylib_echo(env_name: &str) {
     }
 
     // Test basic build functionality with heylib component
-    chdir_to_component("heylib", &state);
+    let component_dir = clone_component_dir("heylib", &state);
 
-    shell_echo(&env_name);
+    shell_echo(&env_name, &state.tempdir.path(), &component_dir);
     info!("ok shell_echo");
 }
 
 #[parameterized(env_name = {"default", "alpine"})]
-#[serial]
 fn test_shell_permissions(env_name: &str) {
     let state = setup();
     if !cfg!(feature = "docker") && env_name == "alpine" {
@@ -121,14 +109,13 @@ fn test_shell_permissions(env_name: &str) {
     }
 
     // Test basic build functionality with heylib component
-    chdir_to_component("heylib", &state);
+    let component_dir = clone_component_dir("heylib", &state);
 
-    shell_permissions(&env_name);
+    shell_permissions(&env_name, &state.tempdir.path(), &component_dir);
     info!("ok shell_permissions");
 }
 
 #[parameterized(env_name = {"default", "alpine"})]
-#[serial]
 fn test_run_scripts(env_name: &str) {
     let state = setup();
     if !cfg!(feature = "docker") && env_name == "alpine" {
@@ -136,45 +123,42 @@ fn test_run_scripts(env_name: &str) {
     }
 
     // Test basic build functionality with heylib component
-    chdir_to_component("heylib", &state);
+    let component_dir = clone_component_dir("heylib", &state);
 
-    run_scripts(&env_name);
+    run_scripts(&env_name, &state.tempdir.path(), &component_dir);
     info!("ok run_scripts");
 }
 
 #[parameterized(env_name = {"default", "alpine"})]
-#[serial]
 fn test_get_environment_and_fetch_no_deps(env_name: &str) {
     let state = setup();
     if !cfg!(feature = "docker") && env_name == "alpine" {
         return;
     }
 
-    chdir_to_component("heylib", &state);
+    let component_dir = clone_component_dir("heylib", &state);
 
-    get_environment_and_fetch(&env_name, &state.backend);
+    get_environment_and_fetch(&component_dir, &env_name, &state.backend, &state.tempdir.path());
     info!("ok get_environment_and_fetch");
 }
 
 #[parameterized(env_name = {"default", "alpine"})]
-#[serial]
 fn test_get_environment_and_fetch_with_deps(env_name: &str) {
     let state = setup();
     if !cfg!(feature = "docker") && env_name == "alpine" {
         return;
     }
 
-    chdir_to_component("heylib", &state);
-    fetch_release_build_and_publish(&env_name, &state.backend);
+    let component_dir = clone_component_dir("heylib", &state);
+    fetch_release_build_and_publish(&component_dir, &env_name, &state.backend, &state.tempdir.path());
     info!("ok fetch_release_build_and_publish heylib");
 
-    chdir_to_component("helloworld", &state);
-    get_environment_and_fetch(&env_name, &state.backend);
+    let component_dir = clone_component_dir("helloworld", &state);
+    get_environment_and_fetch(&component_dir, &env_name, &state.backend, &state.tempdir.path());
     info!("ok get_environment_and_fetch");
 }
 
 #[parameterized(env_name = {"default", "alpine"})]
-#[serial]
 fn test_build_and_stash_update_self(env_name: &str) {
     let state = setup();
     if !cfg!(feature = "docker") && env_name == "alpine" {
@@ -182,16 +166,15 @@ fn test_build_and_stash_update_self(env_name: &str) {
     }
 
     // Test basic build functionality with heylib component
-    chdir_to_component("heylib", &state);
-    build_and_stash_update_self(&env_name, &state.backend);
+    let component_dir = clone_component_dir("heylib", &state);
+    build_and_stash_update_self(&component_dir, &env_name, &state.backend, &state.tempdir.path());
     info!("ok build_and_stash_update_self");
 
-    list_everything();
+    list_everything(&state.tempdir.path(), &component_dir);
     info!("ok list_everything");
 }
 
 #[parameterized(env_name = {"default", "alpine"})]
-#[serial]
 fn test_status_on_experimental(env_name: &str) {
     let state = setup();
     if !cfg!(feature = "docker") && env_name == "alpine" {
@@ -199,17 +182,16 @@ fn test_status_on_experimental(env_name: &str) {
     }
 
     // Test basic build functionality with heylib component
-    chdir_to_component("heylib", &state);
+    let component_dir = clone_component_dir("heylib", &state);
 
-    build_and_stash_update_self(&env_name, &state.backend);
+    build_and_stash_update_self(&component_dir, &env_name, &state.backend, &state.tempdir.path());
     info!("ok build_and_stash_update_self");
 
-    status_on_experimentals();
+    status_on_experimentals(&component_dir);
     info!("ok status_on_experimentals");
 }
 
 #[parameterized(env_name = {"default", "alpine"})]
-#[serial]
 fn test_fetch_release_build_and_publish(env_name: &str) {
     let state = setup();
     if !cfg!(feature = "docker") && env_name == "alpine" {
@@ -217,16 +199,15 @@ fn test_fetch_release_build_and_publish(env_name: &str) {
     }
 
     // Test basic build functionality with heylib component
-    chdir_to_component("heylib", &state);
-    fetch_release_build_and_publish(&env_name, &state.backend);
+    let component_dir = clone_component_dir("heylib", &state);
+    fetch_release_build_and_publish(&component_dir, &env_name, &state.backend, &state.tempdir.path());
     info!("ok fetch_release_build_and_publish heylib");
 
-    list_everything();
+    list_everything(&state.tempdir.path(), &component_dir);
     info!("ok list_everything");
 }
 
 #[parameterized(env_name = {"default", "alpine"})]
-#[serial]
 fn test_no_publish_non_release_builds(env_name: &str) {
     let state = setup();
     if !cfg!(feature = "docker") && env_name == "alpine" {
@@ -234,14 +215,13 @@ fn test_no_publish_non_release_builds(env_name: &str) {
     }
 
     // Test basic build functionality with heylib component
-    chdir_to_component("heylib", &state);
+    let component_dir = clone_component_dir("heylib", &state);
 
-    no_publish_non_release_builds(&env_name, &state.backend);
+    no_publish_non_release_builds(&component_dir, &env_name, &state.backend, &state.tempdir.path());
     info!("ok no_publish_non_release_builds heylib");
 }
 
 #[parameterized(env_name = {"default", "alpine"})]
-#[serial]
 fn test_update_save(env_name: &str) {
     let state = setup();
     if !cfg!(feature = "docker") && env_name == "alpine" {
@@ -249,21 +229,20 @@ fn test_update_save(env_name: &str) {
     }
 
     // "helloworld" depends on "heylib"
-    chdir_to_component("heylib", &state);
-    fetch_release_build_and_publish(&env_name, &state.backend);
+    let component_dir = clone_component_dir("heylib", &state);
+    fetch_release_build_and_publish(&component_dir, env_name, &state.backend, &state.tempdir.path());
     info!("ok fetch_release_build_and_publish heylib");
 
     // switch to "helloworld" component
-    chdir_to_component("helloworld", &state);
+    let component_dir = clone_component_dir("helloworld", &state);
 
     // Fetch published dependencies into ./INPUT
     // update to versions listed in the manifest
-    update_save(&env_name, &state.backend);
+    update_save(&component_dir, &env_name, &state.backend);
     info!("ok update_save");
 }
 
 #[parameterized(env_name = {"default", "alpine"})]
-#[serial]
 fn test_verify_checks(env_name: &str) {
     let state = setup();
     if !cfg!(feature = "docker") && env_name == "alpine" {
@@ -271,20 +250,19 @@ fn test_verify_checks(env_name: &str) {
     }
 
     // "helloworld" depends on "heylib"
-    chdir_to_component("heylib", &state);
-    fetch_release_build_and_publish(&env_name, &state.backend);
+    let component_dir = clone_component_dir("heylib", &state);
+    fetch_release_build_and_publish(&component_dir, &env_name, &state.backend, &state.tempdir.path());
     info!("ok fetch_release_build_and_publish heylib");
 
     // switch to "helloworld" component
-    chdir_to_component("helloworld", &state);
+    let component_dir = clone_component_dir("helloworld", &state);
 
-    verify_checks(&env_name, &state.backend);
+    verify_checks(&component_dir, &env_name, &state.backend);
     info!("ok verify_checks");
 }
 
 
 #[parameterized(env_name = {"default", "alpine"})]
-#[serial]
 fn test_release_build_and_publish(env_name: &str) {
     let state = setup();
     if !cfg!(feature = "docker") && env_name == "alpine" {
@@ -292,21 +270,20 @@ fn test_release_build_and_publish(env_name: &str) {
     }
 
     // "helloworld" depends on "heylib"
-    chdir_to_component("heylib", &state);
-    fetch_release_build_and_publish(&env_name, &state.backend);
+    let component_dir = clone_component_dir("heylib", &state);
+    fetch_release_build_and_publish(&component_dir, &env_name, &state.backend, &state.tempdir.path());
     info!("ok fetch_release_build_and_publish heylib");
 
     // switch to "helloworld" component
-    chdir_to_component("helloworld", &state);
-    fetch_release_build_and_publish(&env_name, &state.backend);
+    let component_dir = clone_component_dir("helloworld", &state);
+    fetch_release_build_and_publish(&component_dir, &env_name, &state.backend, &state.tempdir.path());
     info!("ok fetch_release_build_and_publish helloworld");
 
-    list_everything();
+    list_everything(&state.tempdir.path(), &component_dir);
     info!("ok list_everything");
 }
 
 #[parameterized(env_name = {"default", "alpine"})]
-#[serial]
 fn test_remove_dependencies(env_name: &str) {
     let state = setup();
     if !cfg!(feature = "docker") && env_name == "alpine" {
@@ -314,14 +291,13 @@ fn test_remove_dependencies(env_name: &str) {
     }
 
     // "helloworld" has 1 dependency
-    chdir_to_component("helloworld", &state);
+    let component_dir = clone_component_dir("helloworld", &state);
 
-    remove_dependencies();
+    remove_dependencies(&component_dir);
     info!("ok remove_dependencies");
 }
 
 #[parameterized(env_name = {"default", "alpine"})]
-#[serial]
 fn test_export_checks(env_name: &str) {
     let state = setup();
     if !cfg!(feature = "docker") && env_name == "alpine" {
@@ -329,23 +305,21 @@ fn test_export_checks(env_name: &str) {
     }
 
     // "helloworld" depends on "heylib"
-    chdir_to_component("heylib", &state);
-    fetch_release_build_and_publish(&env_name, &state.backend);
+    let component_dir = clone_component_dir("heylib", &state);
+    fetch_release_build_and_publish(&component_dir, &env_name, &state.backend, &state.tempdir.path());
     info!("ok fetch_release_build_and_publish heylib");
 
     // switch to "helloworld" component
-    chdir_to_component("helloworld", &state);
-    fetch_release_build_and_publish(&env_name, &state.backend);
+    let component_dir = clone_component_dir("helloworld", &state);
+    fetch_release_build_and_publish(&component_dir, &env_name, &state.backend, &state.tempdir.path());
     info!("ok fetch_release_build_and_publish helloworld");
 
     // back to tmpdir to test export and clean
-    assert!(env::set_current_dir(config_dir(None)).is_ok());
-    export_check(&env_name, &state.backend);
+    export_check(&env_name, &state.backend, &component_dir);
     info!("ok export_check");
 }
 
 #[parameterized(env_name = {"default", "alpine"})]
-#[serial]
 fn test_query_check(env_name: &str) {
     let state = setup();
     if !cfg!(feature = "docker") && env_name == "alpine" {
@@ -353,24 +327,20 @@ fn test_query_check(env_name: &str) {
     }
 
     // "helloworld" depends on "heylib"
-    chdir_to_component("heylib", &state);
-    fetch_release_build_and_publish(&env_name, &state.backend);
+    let component_dir = clone_component_dir("heylib", &state);
+    fetch_release_build_and_publish(&component_dir, &env_name, &state.backend, &state.tempdir.path());
     info!("ok fetch_release_build_and_publish heylib");
 
     // switch to "helloworld" component
-    chdir_to_component("helloworld", &state);
-    fetch_release_build_and_publish(&env_name, &state.backend);
+    let component_dir = clone_component_dir("helloworld", &state);
+    fetch_release_build_and_publish(&component_dir, &env_name, &state.backend, &state.tempdir.path());
     info!("ok fetch_release_build_and_publish helloworld");
-
-    // back to tmpdir to test export and clean
-    assert!(env::set_current_dir(config_dir(None)).is_ok());
 
     query_check(&env_name, &state.backend);
     info!("ok query_check");
 }
 
 #[parameterized(env_name = {"default", "alpine"})]
-#[serial]
 fn test_clean_check(env_name: &str) {
     let state = setup();
     if !cfg!(feature = "docker") && env_name == "alpine" {
@@ -378,24 +348,20 @@ fn test_clean_check(env_name: &str) {
     }
 
     // "helloworld" depends on "heylib"
-    chdir_to_component("heylib", &state);
-    fetch_release_build_and_publish(&env_name, &state.backend);
+    let component_dir = clone_component_dir("heylib", &state);
+    fetch_release_build_and_publish(&component_dir, &env_name, &state.backend, &state.tempdir.path());
     info!("ok fetch_release_build_and_publish heylib");
 
     // switch to "helloworld" component
-    chdir_to_component("helloworld", &state);
-    fetch_release_build_and_publish(&env_name, &state.backend);
+    let component_dir = clone_component_dir("helloworld", &state);
+    fetch_release_build_and_publish(&component_dir, &env_name, &state.backend, &state.tempdir.path());
     info!("ok fetch_release_build_and_publish helloworld");
 
-    // back to tmpdir to test export and clean
-    assert!(env::set_current_dir(config_dir(None)).is_ok());
-
-    clean_check();
+    clean_check(&state.tempdir.path());
     info!("ok clean_check");
 }
 
 #[parameterized(env_name = {"default", "alpine"})]
-#[serial]
 fn test_init_force(env_name: &str) {
     let state = setup();
     if !cfg!(feature = "docker") && env_name == "alpine" {
@@ -404,21 +370,19 @@ fn test_init_force(env_name: &str) {
 
     let component = state.tempdir.path().join("new_component");
     fs::create_dir(&component).unwrap();
-    assert!(env::set_current_dir(component).is_ok(), "set current dir");
 
     // test out some functionality regarding creating of new components
-    init_force(&env_name);
+    init_force(&env_name, &state.tempdir.path(), &component);
     info!("ok init_force");
 
-    has_config_and_manifest();
+    has_config_and_manifest(&state.tempdir.path(), &component);
     info!("ok has_config_and_manifest");
 
-    list_everything();
+    list_everything(&state.tempdir.path(), &component);
     info!("ok list_everything");
 }
 
 #[parameterized(env_name = {"default", "alpine"})]
-#[serial]
 fn test_change_envs(env_name: &str) {
     let state = setup();
     if !cfg!(feature = "docker") && env_name == "alpine" {
@@ -427,18 +391,16 @@ fn test_change_envs(env_name: &str) {
 
     let component = state.tempdir.path().join("new_component");
     fs::create_dir(&component).unwrap();
-    assert!(env::set_current_dir(component).is_ok(), "set current dir");
 
-    init_force(&env_name);
+    init_force(&env_name, &state.tempdir.path(), &component);
     info!("ok init_force");
 
-    change_envs();
+    change_envs(&state.tempdir.path(), &component);
     info!("ok change_envs");
 }
 
 
 #[parameterized(env_name = {"default", "alpine"})]
-#[serial]
 fn test_propagations(env_name: &str) {
     let state = setup();
     if !cfg!(feature = "docker") && env_name == "alpine" {
@@ -446,83 +408,75 @@ fn test_propagations(env_name: &str) {
     }
 
     // verify propagations by building prop-leaf -> prop-mid-X -> prop-base
-    chdir_to_component("prop-leaf", &state);
-    fetch_release_build_and_publish(&env_name, &state.backend);
+    let component_dir = clone_component_dir("prop-leaf", &state);
+    fetch_release_build_and_publish(&component_dir, &env_name, &state.backend, &state.tempdir.path());
     info!("ok fetch_release_build_and_publish prop-leaf");
 
-    chdir_to_component("prop-mid-1", &state);
-    fetch_release_build_and_publish(&env_name, &state.backend);
+    let component_dir = clone_component_dir("prop-mid-1", &state);
+    fetch_release_build_and_publish(&component_dir, &env_name, &state.backend, &state.tempdir.path());
     info!("ok fetch_release_build_and_publish prop-mid-1");
 
-    chdir_to_component("prop-mid-2", &state);
-    fetch_release_build_and_publish(&env_name, &state.backend);
+    let component_dir = clone_component_dir("prop-mid-2", &state);
+    fetch_release_build_and_publish(&component_dir, &env_name, &state.backend, &state.tempdir.path());
     info!("ok fetch_release_build_and_publish prop-mid-2");
 
-    chdir_to_component("prop-base", &state);
-    fetch_release_build_and_publish(&env_name, &state.backend);
+    let component_dir = clone_component_dir("prop-base", &state);
+    fetch_release_build_and_publish(&component_dir, &env_name, &state.backend, &state.tempdir.path());
     info!("ok fetch_release_build_and_publish prop-base");
 
-    check_propagation("prop-leaf");
+    check_propagation(&component_dir, "prop-leaf");
     info!("ok check_propagation prop-leaf -> prop-base");
 }
 
-fn kill_laldir() {
-    let laldir = config_dir(None);
-    if laldir.is_dir() {
-        fs::remove_dir_all(&laldir).unwrap();
-    }
-    assert_eq!(laldir.is_dir(), false);
-}
-
-fn remove_dependencies() {
-    let mf = Manifest::read().unwrap();
+fn remove_dependencies(component_dir: &Path) {
+    let mf = Manifest::read(&component_dir).unwrap();
     let xs = mf.dependencies.keys().cloned().collect::<Vec<_>>();
     assert_eq!(xs.len(), 1);
 
-    let r = lal::remove(&mf, xs.clone(), false, false);
+    let r = lal::remove(&component_dir, &mf, xs.clone(), false, false);
     assert!(r.is_ok(), "could lal rm all dependencies");
 
-    let rs = lal::remove(&mf, xs, true, false);
+    let rs = lal::remove(&component_dir, &mf, xs, true, false);
     assert!(rs.is_ok(), "could lal rm all dependencies and save");
 
     // should be no dependencies now
-    let mf2 = Manifest::read().unwrap();
+    let mf2 = Manifest::read(&component_dir).unwrap();
     let xs2 = mf2.dependencies.keys().cloned().collect::<Vec<_>>();
     assert_eq!(xs2.len(), 0);
 }
 
-fn change_envs() {
-    let cfg = Config::read().unwrap();
-    let mf = Manifest::read().unwrap();
+fn change_envs(home: &Path, component_dir: &Path) {
+    let cfg = Config::read(Some(&home)).unwrap();
+    let mf = Manifest::read(&component_dir).unwrap();
 
     // no sticky flags set yet
-    let sticky_none = StickyOptions::read().unwrap();
+    let sticky_none = StickyOptions::read(&component_dir).unwrap();
     assert_eq!(sticky_none.env, None);
 
     // update the container associated with the default env
     // (on CI we've already done this at test start => cheap)
     let environment = cfg.get_environment(mf.environment.clone()).unwrap();
-    let ru = lal::env::update(&environment, &mf.environment);
+    let ru = lal::env::update(&component_dir, &environment, &mf.environment);
     assert!(ru.is_ok(), "env update succeeded");
 
-    let rc = lal::env::set(&sticky_none, &cfg, "xenial");
+    let rc = lal::env::set(&component_dir, &sticky_none, &cfg, "xenial");
     assert!(rc.is_ok(), "env set xenial succeeded");
 
     // we changed the sticky option with that
-    let sticky_set = StickyOptions::read().unwrap();
+    let sticky_set = StickyOptions::read(&component_dir).unwrap();
     assert_eq!(sticky_set.env, Some("xenial".into()));
 
-    let rc = lal::env::clear();
+    let rc = lal::env::clear(&component_dir);
     assert!(rc.is_ok(), "env clear succeeded");
 
     // we cleared the stickies with that
-    let sticky_clear = StickyOptions::read().unwrap();
+    let sticky_clear = StickyOptions::read(&component_dir).unwrap();
     assert_eq!(sticky_clear.env, None);
 }
 
-fn list_everything() {
-    let cfg = Config::read().unwrap();
-    let mf = Manifest::read().unwrap();
+fn list_everything(home: &Path, component_dir: &Path) {
+    let cfg = Config::read(Some(&home)).unwrap();
+    let mf = Manifest::read(&component_dir).unwrap();
 
     let re = lal::list::environments(&cfg);
     assert!(re.is_ok(), "list envs succeeded");
@@ -539,16 +493,14 @@ fn list_everything() {
     assert!(rb.is_ok(), "list buildables succeeded");
 }
 
-fn configure_local_backend(demo_config: &PathBuf) -> LocalBackend {
-    kill_laldir();
-
-    let config = Config::read();
+fn configure_local_backend(demo_config: &PathBuf, home: &Path) -> LocalBackend {
+    let config = Config::read(Some(&home));
     assert!(config.is_err(), "no config at this point");
 
-    let r = lal::configure(true, false, demo_config.as_os_str().to_str().unwrap());
+    let r = lal::configure(true, false, demo_config.as_os_str().to_str().unwrap(), Some(&home));
     assert!(r.is_ok(), "configure succeeded");
 
-    let cfg = Config::read();
+    let cfg = Config::read(Some(&home));
     assert!(cfg.is_ok(), "config exists now");
 
     let cfgu = cfg.unwrap();
@@ -560,46 +512,45 @@ fn configure_local_backend(demo_config: &PathBuf) -> LocalBackend {
 }
 
 // Create manifest in a weird directory
-fn init_force(env_name: &str) {
-    let cfg = Config::read().expect("read config");
+fn init_force(env_name: &str, home: &Path, component_dir: &Path) {
+    let cfg = Config::read(Some(&home)).expect("read config");
 
-    let m1 = Manifest::read();
+    let m1 = Manifest::read(&component_dir);
     assert!(m1.is_err(), "no manifest at this point");
 
     // Creates a manifest in the testtmp directory
-    let m2 = lal::init(&cfg, false, env_name);
+    let m2 = lal::init(&cfg, false, &component_dir, env_name);
     assert!(m2.is_ok(), "could init without force param");
 
-    let m3 = lal::init(&cfg, true, env_name);
+    let m3 = lal::init(&cfg, true, &component_dir, env_name);
     assert!(m3.is_ok(), "could re-init with force param");
 
-    let m4 = lal::init(&cfg, false, env_name);
+    let m4 = lal::init(&cfg, false, &component_dir, env_name);
     assert!(m4.is_err(), "could not re-init without force ");
 
-    let m5 = lal::init(&cfg, true, "blah");
+    let m5 = lal::init(&cfg, true, &component_dir, "blah");
     assert!(m5.is_err(), "could not init without valid environment");
 }
 
 // Tests need to be run in a directory with a manifest
 // and ~/.lal + config must exist
-fn has_config_and_manifest() {
-    let ldir = config_dir(None);
-    assert!(ldir.is_dir(), "have laldir");
+fn has_config_and_manifest(home: &Path, component_dir: &Path) {
+    assert!(home.is_dir(), "have laldir");
 
-    let cfg = Config::read();
+    let cfg = Config::read(Some(&home));
     assert!(cfg.is_ok(), "could read config");
 
-    let manifest = Manifest::read();
+    let manifest = Manifest::read(&component_dir);
     assert!(manifest.is_ok(), "could read manifest");
 
     // There is no INPUT yet, but we have no dependencies, so this should work:
-    let r = lal::verify(&manifest.unwrap(), "xenial".into(), false);
+    let r = lal::verify(&component_dir, &manifest.unwrap(), "xenial".into(), false);
     assert!(r.is_ok(), "could verify after install");
 }
 
 // Shell tests
-fn shell_echo(env_name: &str) {
-    let cfg = Config::read().unwrap();
+fn shell_echo(env_name: &str, home: &Path, component_dir: &Path) {
+    let cfg = Config::read(Some(&home)).unwrap();
     let environment = cfg.get_environment(env_name.into()).unwrap();
     let modes = ShellModes::default();
     let r = lal::run(
@@ -608,12 +559,13 @@ fn shell_echo(env_name: &str) {
         vec!["echo".to_string(), "# echo from docker".to_string()],
         &DockerRunFlags::default(),
         &modes,
+        &component_dir,
     );
     assert!(r.is_ok(), "shell echoed");
 }
 
-fn shell_permissions(env_name: &str) {
-    let cfg = Config::read().unwrap();
+fn shell_permissions(env_name: &str, home: &Path, component_dir: &Path) {
+    let cfg = Config::read(Some(&home)).unwrap();
     let environment = cfg.get_environment(env_name.into()).unwrap();
     let modes = ShellModes::default();
     let r = lal::run(
@@ -622,13 +574,14 @@ fn shell_permissions(env_name: &str) {
         vec!["touch".to_string(), "README.md".to_string()],
         &DockerRunFlags::default(),
         &modes,
+        &component_dir,
     );
     assert!(r.is_ok(), "could touch files in container");
 }
 
-fn build_and_stash_update_self<T: CachedBackend + Backend>(env_name: &str, backend: &T) {
-    let mf = Manifest::read().expect("Read manifest");
-    let cfg = Config::read().expect("Read config");
+fn build_and_stash_update_self<T: CachedBackend + Backend>(component_dir: &Path, env_name: &str, backend: &T, home: &Path) {
+    let cfg = Config::read(Some(&home)).expect("Read config");
+    let mf = Manifest::read(&component_dir).expect("Read manifest");
     let environment = cfg.get_environment(env_name.into()).expect("get environment");
 
     // we'll try with various build options further down with various deps
@@ -644,18 +597,19 @@ fn build_and_stash_update_self<T: CachedBackend + Backend>(env_name: &str, backe
     };
     let modes = ShellModes::default();
     // basic build works - all deps are global at right env
-    let r = lal::build(&cfg, &mf, &bopts, env_name.into(), modes.clone());
+    let r = lal::build(&component_dir, &cfg, &mf, &bopts, env_name.into(), modes.clone());
     if let Err(e) = r {
         println!("error from build: {:?}", e);
         assert!(false, "could perform a '{}' build", env_name);
     }
 
     // lal stash blah
-    let rs = lal::stash(backend, &mf, "blah");
+    let rs = lal::stash(&component_dir, backend, &mf, "blah");
     assert!(rs.is_ok(), "could stash lal build artifact");
 
     // lal update heylib=blah
     let ru = lal::update(
+        &component_dir,
         &mf,
         backend,
         vec!["heylib=blah".to_string()],
@@ -666,7 +620,7 @@ fn build_and_stash_update_self<T: CachedBackend + Backend>(env_name: &str, backe
     assert!(ru.is_ok(), "could update heylib from stash");
 
     // basic build won't work now without simple verify
-    let r1 = lal::build(&cfg, &mf, &bopts, env_name.into(), modes.clone());
+    let r1 = lal::build(&component_dir, &cfg, &mf, &bopts, env_name.into(), modes.clone());
     assert!(r1.is_err(), "could not verify a new '{}' build", env_name);
     if let Err(CliError::NonGlobalDependencies(nonglob)) = r1 {
         assert_eq!(nonglob, "heylib");
@@ -676,11 +630,11 @@ fn build_and_stash_update_self<T: CachedBackend + Backend>(env_name: &str, backe
     }
 
     bopts.simple_verify = true;
-    let r2 = lal::build(&cfg, &mf, &bopts, env_name.into(), modes.clone());
+    let r2 = lal::build(&component_dir, &cfg, &mf, &bopts, env_name.into(), modes.clone());
     assert!(r2.is_ok(), "can build with stashed deps with simple verify");
 
     // force will also work - even with stashed deps from wrong env
-    let renv = lal::build(&cfg, &mf, &bopts, "xenial".into(), modes.clone());
+    let renv = lal::build(&component_dir, &cfg, &mf, &bopts, "xenial".into(), modes.clone());
     assert!(renv.is_err(), "cannot build with simple verify when wrong env");
     if let Err(CliError::EnvironmentMismatch(_, compenv)) = renv {
         assert_eq!(compenv, env_name); // expected complaints about xenial env
@@ -692,7 +646,7 @@ fn build_and_stash_update_self<T: CachedBackend + Backend>(env_name: &str, backe
     // settings that reflect lal build -f
     bopts.simple_verify = false;
     bopts.force = true;
-    let renv2 = lal::build(&cfg, &mf, &bopts, "xenial".into(), modes.clone());
+    let renv2 = lal::build(&component_dir, &cfg, &mf, &bopts, "xenial".into(), modes.clone());
     assert!(renv2.is_ok(), "could force build in different env");
 
     // additionally do a build with printonly
@@ -702,26 +656,26 @@ fn build_and_stash_update_self<T: CachedBackend + Backend>(env_name: &str, backe
         host_networking: true,
         env_vars: vec![],
     };
-    let printbuild = lal::build(&cfg, &mf, &bopts, "alpine".into(), all_modes);
+    let printbuild = lal::build(&component_dir, &cfg, &mf, &bopts, "alpine".into(), all_modes);
     // TODO: verify output!
     assert!(printbuild.is_ok(), "saw docker run print with X11 mounts");
 }
 
-fn get_environment_and_fetch<T: CachedBackend + Backend>(env_name: &str, backend: &T) {
-    let mf = Manifest::read().unwrap();
-    let cfg = Config::read().unwrap();
+fn get_environment_and_fetch<T: CachedBackend + Backend>(component_dir: &Path, env_name: &str, backend: &T, home: &Path) {
+    let mf = Manifest::read(&component_dir).unwrap();
+    let cfg = Config::read(Some(&home)).unwrap();
     let _environment = cfg.get_environment(env_name.into()).unwrap();
 
-    let rcore = lal::fetch(&mf, backend, true, env_name);
+    let rcore = lal::fetch(&component_dir, &mf, backend, true, env_name);
     assert!(rcore.is_ok(), "install core succeeded");
 }
 
-fn fetch_release_build_and_publish<T: CachedBackend + Backend>(env_name: &str, backend: &T) {
-    let mf = Manifest::read().unwrap();
-    let cfg = Config::read().unwrap();
+fn fetch_release_build_and_publish<T: CachedBackend + Backend>(component_dir: &Path, env_name: &str, backend: &T, home: &Path) {
+    let cfg = Config::read(Some(&home)).unwrap();
+    let mf = Manifest::read(&component_dir).unwrap();
     let environment = cfg.get_environment(env_name.into()).unwrap();
 
-    let rcore = lal::fetch(&mf, backend, true, env_name);
+    let rcore = lal::fetch(&component_dir, &mf, backend, true, env_name);
     assert!(rcore.is_ok(), "install core succeeded");
 
     // we'll try with various build options further down with various deps
@@ -736,19 +690,18 @@ fn fetch_release_build_and_publish<T: CachedBackend + Backend>(env_name: &str, b
         simple_verify: false,
     };
     let modes = ShellModes::default();
-    let r = lal::build(&cfg, &mf, &bopts, env_name.into(), modes.clone());
-    assert!(r.is_ok(), "could build in release");
+    lal::build(&component_dir, &cfg, &mf, &bopts, env_name.into(), modes.clone()).expect("could build in release");
 
-    let rp = lal::publish(&mf.name, backend);
+    let rp = lal::publish(Some(&home), &component_dir, &mf.name, backend);
     assert!(rp.is_ok(), "could publish");
 }
 
-fn no_publish_non_release_builds<T: CachedBackend + Backend>(env_name: &str, backend: &T) {
-    let mf = Manifest::read().unwrap();
-    let cfg = Config::read().unwrap();
+fn no_publish_non_release_builds<T: CachedBackend + Backend>(component_dir: &Path, env_name: &str, backend: &T, home: &Path) {
+    let cfg = Config::read(Some(&home)).unwrap();
+    let mf = Manifest::read(&component_dir).unwrap();
     let environment = cfg.get_environment(env_name.into()).unwrap();
 
-    let artifact_dir = Path::new("./ARTIFACT");
+    let artifact_dir = component_dir.join("./ARTIFACT");
     if artifact_dir.is_dir() {
         debug!("Deleting existing artifact dir");
         fs::remove_dir_all(&artifact_dir).unwrap();
@@ -765,116 +718,118 @@ fn no_publish_non_release_builds<T: CachedBackend + Backend>(env_name: &str, bac
         simple_verify: false,
     };
     let modes = ShellModes::default();
-    let r = lal::build(&cfg, &mf, &bopts, env_name.into(), modes.clone());
+    let r = lal::build(&component_dir, &cfg, &mf, &bopts, env_name.into(), modes.clone());
     assert!(r.is_ok(), "could build without non-release");
 
-    let rp = lal::publish(&mf.name, backend);
+    let rp = lal::publish(Some(&home), &component_dir, &mf.name, backend);
     assert!(rp.is_err(), "could not publish non-release build");
 
     bopts.version = None; // missing version bad
     bopts.release = true; // but at least in release mode now
 
-    let rb2 = lal::build(&cfg, &mf, &bopts, env_name.into(), modes.clone());
+    let rb2 = lal::build(&component_dir, &cfg, &mf, &bopts, env_name.into(), modes.clone());
     assert!(rb2.is_ok(), "could build in without version");
 
-    let rp2 = lal::publish(&mf.name, backend);
+    let rp2 = lal::publish(Some(&home), &component_dir, &mf.name, backend);
     assert!(rp2.is_err(), "could not publish without version set");
 }
 
 // add dependencies to test tree
 // NB: this currently shouldn't do anything as all deps are accounted for
 // Thus if this changes test manifests, something is wrong..
-fn update_save<T: CachedBackend + Backend>(env_name: &str, backend: &T) {
-    let mf1 = Manifest::read().unwrap();
+fn update_save<T: CachedBackend + Backend>(component_dir: &Path, env_name: &str, backend: &T) {
+    let mf1 = Manifest::read(&component_dir).unwrap();
 
     // update heylib --save
-    let ri = lal::update(&mf1, backend, vec!["heylib=1".to_string()], true, false, env_name);
+    let ri = lal::update(&component_dir, &mf1, backend, vec!["heylib=1".to_string()], true, false, env_name);
     ri.expect("could update heylib and save");
 
     // main deps (and re-read manifest to avoid overwriting devedps)
-    let mf2 = Manifest::read().unwrap();
+    let mf2 = Manifest::read(&component_dir).unwrap();
     let updates = vec![
         "heylib".to_string(),
         // TODO: more deps
     ];
-    let ri = lal::update(&mf2, backend, updates, true, false, env_name);
+    let ri = lal::update(&component_dir, &mf2, backend, updates, true, false, env_name);
     assert!(ri.is_ok(), "could update and save");
 
     // verify update-all --save
-    let mf3 = Manifest::read().unwrap();
-    let ri = lal::update_all(&mf3, backend, true, false, env_name);
+    let mf3 = Manifest::read(&component_dir).unwrap();
+    let ri = lal::update_all(&component_dir, &mf3, backend, true, false, env_name);
     assert!(ri.is_ok(), "could update all and --save");
 
     // verify update-all --save --dev
-    let mf4 = Manifest::read().unwrap();
-    let ri = lal::update_all(&mf4, backend, false, true, env_name);
+    let mf4 = Manifest::read(&component_dir).unwrap();
+    let ri = lal::update_all(&component_dir, &mf4, backend, false, true, env_name);
     assert!(ri.is_ok(), "could update all and --save --dev");
 }
 
-fn verify_checks<T: CachedBackend + Backend>(env_name: &str, backend: &T) {
-    let mf = Manifest::read().unwrap();
+fn verify_checks<T: CachedBackend + Backend>(component_dir: &Path, env_name: &str, backend: &T) {
+    let mf = Manifest::read(&component_dir).unwrap();
 
-    let rcore = lal::fetch(&mf, backend, true, env_name);
+    let rcore = lal::fetch(&component_dir, &mf, backend, true, env_name);
     assert!(rcore.is_ok(), "install core succeeded");
 
-    let r = lal::verify(&mf, env_name.into(), false);
+    let r = lal::verify(&component_dir, &mf, env_name.into(), false);
     assert!(r.is_ok(), "could verify after install");
 
-    let renv1 = lal::verify(&mf, "xenial".into(), false);
+    let renv1 = lal::verify(&component_dir, &mf, "xenial".into(), false);
     assert!(renv1.is_err(), "could not verify with wrong env");
-    let renv2 = lal::verify(&mf, "xenial".into(), true);
+    let renv2 = lal::verify(&component_dir, &mf, "xenial".into(), true);
     assert!(
         renv2.is_err(),
         "could not verify with wrong env - even with simple"
     );
 
-    let heylib = Path::new(&env::current_dir().unwrap())
+    let heylib = Path::new(&component_dir)
         .join("INPUT")
         .join("heylib");
     // clean folders and verify it fails
     fs::remove_dir_all(&heylib).unwrap();
 
-    let r2 = lal::verify(&mf, env_name.into(), false);
+    let r2 = lal::verify(&component_dir, &mf, env_name.into(), false);
     assert!(r2.is_err(), "verify failed after fiddling");
 
     // fetch --core, resyncs with core deps (removes devDeps and other extraneous)
-    let rcore = lal::fetch(&mf, backend, true, env_name);
+    let rcore = lal::fetch(&component_dir, &mf, backend, true, env_name);
     assert!(rcore.is_ok(), "install core succeeded");
     assert!(heylib.is_dir(), "heylib was reinstalled from manifest");
     // TODO: add dev dep to verify it wasn't reinstalled here
     // assert!(!gtest.is_dir(), "gtest was was extraneous with --core => removed");
 
     // fetch --core also doesn't install else again
-    let rcore2 = lal::fetch(&mf, backend, true, env_name);
+    let rcore2 = lal::fetch(&component_dir, &mf, backend, true, env_name);
     assert!(rcore2.is_ok(), "install core succeeded 2");
     assert!(heylib.is_dir(), "heylib still there");
     // assert!(!gtest.is_dir(), "gtest was not reinstalled with --core");
 
     // and it is finally installed if we ask for non-core as well
-    let rall = lal::fetch(&mf, backend, false, env_name);
+    let rall = lal::fetch(&component_dir, &mf, backend, false, env_name);
     assert!(rall.is_ok(), "install all succeeded");
     // assert!(gtest.is_dir(), "gtest is otherwise installed again");
 
-    let r3 = lal::verify(&mf, env_name, false);
+    let r3 = lal::verify(&component_dir, &mf, env_name, false);
     assert!(r3.is_ok(), "verify ok again");
 }
 
-fn run_scripts(env_name: &str) {
+fn run_scripts(env_name: &str, home: &Path, component_dir: &Path) {
     {
         Command::new("mkdir")
             .arg("-p")
             .arg(".lal/scripts")
+            .current_dir(&component_dir)
             .output()
             .unwrap();
-        let mut f = File::create("./.lal/scripts/subroutine").unwrap();
+        let mut f = File::create(&component_dir.join("./.lal/scripts/subroutine")).unwrap();
         write!(f, "main() {{ echo hi $1 $2 ;}}\n").unwrap();
         Command::new("chmod")
             .arg("+x")
             .arg(".lal/scripts/subroutine")
+            .current_dir(&component_dir)
             .output()
             .unwrap();
     }
-    let cfg = Config::read().unwrap();
+    let cfg = Config::read(Some(&home)).unwrap();
     let environment = cfg.get_environment(env_name.into()).unwrap();
     let modes = ShellModes::default();
     let r = lal::script(
@@ -884,16 +839,17 @@ fn run_scripts(env_name: &str) {
         vec!["there", "mr"],
         &modes,
         false,
+        &component_dir,
     );
     assert!(r.is_ok(), "could run subroutine script");
 }
 
-fn check_propagation(leaf: &str) {
-    let mf = Manifest::read().unwrap();
+fn check_propagation(component_dir: &Path, leaf: &str) {
+    let mf = Manifest::read(&component_dir).unwrap();
 
     let lf = Lockfile::default()
         .set_name(&mf.name)
-        .populate_from_input()
+        .populate_from_input(&component_dir)
         .unwrap();
     if let Ok(res) = lal::propagate::compute(&lf, leaf) {
         assert_eq!(res.stages.len(), 2);
@@ -914,23 +870,23 @@ fn check_propagation(leaf: &str) {
         assert!(false, "could propagate leaf to {}", mf.name);
     }
 
-    let rpj = lal::propagate::print(&mf, leaf, true);
+    let rpj = lal::propagate::print(&component_dir, &mf, leaf, true);
     assert!(rpj.is_ok(), "could print propagate json to stdout");
-    let rp = lal::propagate::print(&mf, leaf, false);
+    let rp = lal::propagate::print(&component_dir, &mf, leaf, false);
     assert!(rp.is_ok(), "could print propagate to stdout");
 
     // print tree for extra coverage of bigger trees
-    let rs = lal::status(&mf, true, true, true);
+    let rs = lal::status(&component_dir, &mf, true, true, true);
     assert!(rs.is_ok(), "could print status of propagation root");
 }
 
-fn status_on_experimentals() {
-    let mf = Manifest::read().unwrap();
+fn status_on_experimentals(component_dir: &Path) {
+    let mf = Manifest::read(&component_dir).unwrap();
 
     // both of these should return errors, but work
-    let r = lal::status(&mf, false, false, false);
+    let r = lal::status(&component_dir, &mf, false, false, false);
     assert!(r.is_err(), "status should complain at experimental deps");
-    let r = lal::status(&mf, true, true, true);
+    let r = lal::status(&component_dir, &mf, true, true, true);
     assert!(r.is_err(), "status should complain at experimental deps");
 }
 
@@ -942,8 +898,8 @@ fn upgrade_does_not_fail() {
     assert!(!upgraded, "we never have upgrades in the tip source tree");
 }
 
-fn clean_check() {
-    let cfg = Config::read().unwrap();
+fn clean_check(home: &Path) {
+    let cfg = Config::read(Some(&home)).unwrap();
     let r = lal::clean(&cfg.cache, 1);
     assert!(r.is_ok(), "could run partial lal cleanup");
 
@@ -974,21 +930,23 @@ fn clean_check() {
     assert!(first2.is_none(), "no artifacts left in cache");
 }
 
-fn export_check<T: CachedBackend + Backend>(env_name: &str, backend: &T) {
-    let tmp = Path::new(".").join("blah");
+fn export_check<T: CachedBackend + Backend>(env_name: &str, backend: &T, component_dir: &Path) {
+    let tmp = component_dir.join("blah");
+    debug!("tmp: {}", tmp.display());
     if !tmp.is_dir() {
         fs::create_dir(&tmp).unwrap();
     }
-    let r = lal::export(backend, "heylib=1", Some("blah"), Some(env_name));
+
+    let r = lal::export(backend, "heylib=1", &tmp, Some(env_name));
     assert!(r.is_ok(), "could export heylib=1 into subdir");
 
-    let r2 = lal::export(backend, "hello", None, Some(env_name));
-    assert!(r2.is_ok(), "could export latest hello into PWD");
+    let r2 = lal::export(backend, "hello", &tmp, Some(env_name));
+    assert!(r2.is_ok(), "could export latest hello into subdir");
 
-    let heylib = Path::new(".").join("blah").join("heylib.tar.gz");
+    let heylib = component_dir.join("blah").join("heylib.tar.gz");
     assert!(heylib.is_file(), "heylib was copied correctly");
 
-    let hello = Path::new(".").join("hello.tar.gz");
+    let hello = component_dir.join("blah").join("hello.tar.gz");
     assert!(hello.is_file(), "hello was copied correctly");
 
     // TODO: verify we can untar and execute hello binary and grep output after #15

--- a/tests/testmain.rs
+++ b/tests/testmain.rs
@@ -497,7 +497,12 @@ fn configure_local_backend(demo_config: &PathBuf, home: &Path) -> LocalBackend {
     let config = Config::read(Some(&home));
     assert!(config.is_err(), "no config at this point");
 
-    let r = lal::configure(true, false, demo_config.as_os_str().to_str().unwrap(), Some(&home));
+    let r = lal::configure(
+        true,
+        false,
+        demo_config.as_os_str().to_str().unwrap(),
+        Some(&home),
+    );
     assert!(r.is_ok(), "configure succeeded");
 
     let cfg = Config::read(Some(&home));
@@ -579,7 +584,12 @@ fn shell_permissions(env_name: &str, home: &Path, component_dir: &Path) {
     assert!(r.is_ok(), "could touch files in container");
 }
 
-fn build_and_stash_update_self<T: CachedBackend + Backend>(component_dir: &Path, env_name: &str, backend: &T, home: &Path) {
+fn build_and_stash_update_self<T: CachedBackend + Backend>(
+    component_dir: &Path,
+    env_name: &str,
+    backend: &T,
+    home: &Path,
+) {
     let cfg = Config::read(Some(&home)).expect("Read config");
     let mf = Manifest::read(&component_dir).expect("Read manifest");
     let environment = cfg.get_environment(env_name.into()).expect("get environment");
@@ -661,7 +671,12 @@ fn build_and_stash_update_self<T: CachedBackend + Backend>(component_dir: &Path,
     assert!(printbuild.is_ok(), "saw docker run print with X11 mounts");
 }
 
-fn get_environment_and_fetch<T: CachedBackend + Backend>(component_dir: &Path, env_name: &str, backend: &T, home: &Path) {
+fn get_environment_and_fetch<T: CachedBackend + Backend>(
+    component_dir: &Path,
+    env_name: &str,
+    backend: &T,
+    home: &Path,
+) {
     let mf = Manifest::read(&component_dir).unwrap();
     let cfg = Config::read(Some(&home)).unwrap();
     let _environment = cfg.get_environment(env_name.into()).unwrap();
@@ -670,7 +685,12 @@ fn get_environment_and_fetch<T: CachedBackend + Backend>(component_dir: &Path, e
     assert!(rcore.is_ok(), "install core succeeded");
 }
 
-fn fetch_release_build_and_publish<T: CachedBackend + Backend>(component_dir: &Path, env_name: &str, backend: &T, home: &Path) {
+fn fetch_release_build_and_publish<T: CachedBackend + Backend>(
+    component_dir: &Path,
+    env_name: &str,
+    backend: &T,
+    home: &Path,
+) {
     let cfg = Config::read(Some(&home)).unwrap();
     let mf = Manifest::read(&component_dir).unwrap();
     let environment = cfg.get_environment(env_name.into()).unwrap();
@@ -690,13 +710,19 @@ fn fetch_release_build_and_publish<T: CachedBackend + Backend>(component_dir: &P
         simple_verify: false,
     };
     let modes = ShellModes::default();
-    lal::build(&component_dir, &cfg, &mf, &bopts, env_name.into(), modes.clone()).expect("could build in release");
+    lal::build(&component_dir, &cfg, &mf, &bopts, env_name.into(), modes.clone())
+        .expect("could build in release");
 
     let rp = lal::publish(Some(&home), &component_dir, &mf.name, backend);
     assert!(rp.is_ok(), "could publish");
 }
 
-fn no_publish_non_release_builds<T: CachedBackend + Backend>(component_dir: &Path, env_name: &str, backend: &T, home: &Path) {
+fn no_publish_non_release_builds<T: CachedBackend + Backend>(
+    component_dir: &Path,
+    env_name: &str,
+    backend: &T,
+    home: &Path,
+) {
     let cfg = Config::read(Some(&home)).unwrap();
     let mf = Manifest::read(&component_dir).unwrap();
     let environment = cfg.get_environment(env_name.into()).unwrap();
@@ -741,7 +767,15 @@ fn update_save<T: CachedBackend + Backend>(component_dir: &Path, env_name: &str,
     let mf1 = Manifest::read(&component_dir).unwrap();
 
     // update heylib --save
-    let ri = lal::update(&component_dir, &mf1, backend, vec!["heylib=1".to_string()], true, false, env_name);
+    let ri = lal::update(
+        &component_dir,
+        &mf1,
+        backend,
+        vec!["heylib=1".to_string()],
+        true,
+        false,
+        env_name,
+    );
     ri.expect("could update heylib and save");
 
     // main deps (and re-read manifest to avoid overwriting devedps)
@@ -781,9 +815,7 @@ fn verify_checks<T: CachedBackend + Backend>(component_dir: &Path, env_name: &st
         "could not verify with wrong env - even with simple"
     );
 
-    let heylib = Path::new(&component_dir)
-        .join("INPUT")
-        .join("heylib");
+    let heylib = Path::new(&component_dir).join("INPUT").join("heylib");
     // clean folders and verify it fails
     fs::remove_dir_all(&heylib).unwrap();
 


### PR DESCRIPTION
Go through the entire codebase and replace all instances where the `current_dir` is assumed.

This lets us remove `LAL_CONFIG_HOME` from the tests and removes all assumptions about
paths because `set_current_dir` is fundamentally incompatible with threads. All threads share the same working directory.