### PR TITLE
Update rust edition to "2018"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "lal"
-version = "3.9.0"
+version = "3.10.0"
 dependencies = [
  "ansi_term 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lal"
-version = "3.9.0"
-authors = ["Eirik Albrigtsen <sszynrae@gmail.com>"]
+version = "3.10.0"
+authors = ["Eirik Albrigtsen <sszynrae@gmail.com>", "Ben Cordero <bencord0@condi.me>"]
 description = "A strict, language-agnostic build system and dependency manager"
 documentation = "http://lalbuild.github.io/lal"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 categories = ["command-line-utilities"]
 keywords = ["package", "dependency", "build", "docker", "artifactory"]
 readme = "README.md"
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "lalbuild/lal", branch = "master" }

--- a/src/build.rs
+++ b/src/build.rs
@@ -4,8 +4,8 @@ use super::{
     ensure_dir_exists_fresh, output, CliError, Config, DockerRunFlags, Environment, LalResult, Lockfile,
     Manifest, ShellModes,
 };
-use shell;
-use verify::verify;
+use crate::shell;
+use crate::verify::verify;
 
 
 fn find_valid_build_script(component_dir: &Path) -> LalResult<String> {

--- a/src/build.rs
+++ b/src/build.rs
@@ -4,8 +4,7 @@ use super::{
     ensure_dir_exists_fresh, output, CliError, Config, DockerRunFlags, Environment, LalResult, Lockfile,
     Manifest, ShellModes,
 };
-use crate::shell;
-use crate::verify::verify;
+use crate::{shell, verify::verify};
 
 
 fn find_valid_build_script(component_dir: &Path) -> LalResult<String> {

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use super::{CliError, Container, Environment, LalResult};
-use storage::BackendConfiguration;
+use crate::storage::BackendConfiguration;
 
 fn find_home_dir() -> PathBuf {
     // Either we have LAL_CONFIG_HOME evar, or HOME

--- a/src/core/container.rs
+++ b/src/core/container.rs
@@ -20,7 +20,7 @@ impl Container {
 }
 
 impl fmt::Display for Container {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}:{}", self.name, self.tag)
     }
 }

--- a/src/core/environment.rs
+++ b/src/core/environment.rs
@@ -13,7 +13,7 @@ pub enum Environment {
 }
 
 impl fmt::Display for Environment {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Environment::Container(container) => write!(f, "{}", container),
             Environment::None => write!(f, "No environment"),

--- a/src/core/errors.rs
+++ b/src/core/errors.rs
@@ -124,7 +124,7 @@ pub enum CliError {
 
 // Format implementation used when printing an error
 impl fmt::Display for CliError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             CliError::Io(ref err) => {
                 let knd = err.kind();

--- a/src/core/sticky.rs
+++ b/src/core/sticky.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use super::LalResult;
-use manifest::create_lal_subdir;
+use crate::manifest::create_lal_subdir;
 
 /// Representation of .lal/opts
 ///

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,7 +1,7 @@
 use std::{fs, path::Path};
 
 use super::{CliError, LalResult};
-use storage::CachedBackend;
+use crate::storage::CachedBackend;
 
 /// Export a specific component from the storage backend
 pub fn export<T: CachedBackend + ?Sized>(

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -1,7 +1,7 @@
 use std::{fs, path::Path};
 
 use super::{CliError, LalResult, Lockfile, Manifest};
-use storage::CachedBackend;
+use crate::storage::CachedBackend;
 
 fn clean_input(component_dir: &Path) {
     let input = component_dir.join("./INPUT");

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,7 +1,7 @@
 use std::path::{Component, Path};
 
 use super::{CliError, Config, LalResult};
-use core::manifest::*;
+use crate::core::manifest::*;
 
 
 /// Generates a blank manifest in the current directory

--- a/src/init.rs
+++ b/src/init.rs
@@ -14,7 +14,7 @@ use crate::core::manifest::*;
 pub fn init(cfg: &Config, force: bool, component_dir: &Path, env: &str) -> LalResult<()> {
     cfg.get_environment(env.into())?;
 
-    let last_comp: Component = component_dir.components().last().unwrap();
+    let last_comp: Component<'_> = component_dir.components().last().unwrap();
     let dirname = last_comp.as_os_str().to_str().unwrap();
 
     let mpath = ManifestLocation::identify(&component_dir.to_path_buf());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,22 +18,22 @@
 //! explicitly or implicitly is listed on the left of this page.
 
 #[macro_use] extern crate hyper;
-extern crate hyper_native_tls;
-extern crate openssl_probe;
+
+
 #[macro_use] extern crate serde_derive;
-extern crate ansi_term;
-extern crate flate2;
-extern crate regex;
-extern crate serde_json;
-extern crate sha1;
-extern crate tar;
+
+
+
+
+
+
 #[macro_use] extern crate log;
-extern crate chrono;
-extern crate filetime;
-#[cfg(feature = "progress")] extern crate indicatif;
-extern crate rand;
-extern crate semver;
-extern crate walkdir;
+
+
+
+
+
+
 
 // re-exports
 mod core;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,13 +37,13 @@ extern crate walkdir;
 
 // re-exports
 mod core;
-pub use core::*;
+pub use crate::core::*;
 
 mod runners;
-pub use runners::*;
+pub use crate::runners::*;
 
 mod storage;
-pub use storage::*;
+pub use crate::storage::*;
 
 /// Env module for env subcommand (which has further subcommands)
 pub mod env;
@@ -55,20 +55,20 @@ pub mod propagate;
 
 // lift most other pub functions into our libraries main scope
 // this avoids having to type lal:build in tests and main.rs
-pub use build::{build, BuildOptions};
-pub use clean::clean;
-pub use configure::configure;
-pub use export::export;
-pub use fetch::fetch;
-pub use init::init;
-pub use publish::publish;
-pub use query::query;
-pub use remove::remove;
-pub use shell::{run, script, shell};
-pub use stash::stash;
-pub use status::status;
-pub use update::{update, update_all};
-pub use verify::verify;
+pub use crate::build::{build, BuildOptions};
+pub use crate::clean::clean;
+pub use crate::configure::configure;
+pub use crate::export::export;
+pub use crate::fetch::fetch;
+pub use crate::init::init;
+pub use crate::publish::publish;
+pub use crate::query::query;
+pub use crate::remove::remove;
+pub use crate::shell::{run, script, shell};
+pub use crate::stash::stash;
+pub use crate::status::status;
+pub use crate::update::{update, update_all};
+pub use crate::verify::verify;
 
 mod build;
 mod clean;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,16 +23,7 @@
 #[macro_use] extern crate serde_derive;
 
 
-
-
-
-
 #[macro_use] extern crate log;
-
-
-
-
-
 
 
 // re-exports
@@ -55,20 +46,22 @@ pub mod propagate;
 
 // lift most other pub functions into our libraries main scope
 // this avoids having to type lal:build in tests and main.rs
-pub use crate::build::{build, BuildOptions};
-pub use crate::clean::clean;
-pub use crate::configure::configure;
-pub use crate::export::export;
-pub use crate::fetch::fetch;
-pub use crate::init::init;
-pub use crate::publish::publish;
-pub use crate::query::query;
-pub use crate::remove::remove;
-pub use crate::shell::{run, script, shell};
-pub use crate::stash::stash;
-pub use crate::status::status;
-pub use crate::update::{update, update_all};
-pub use crate::verify::verify;
+pub use crate::{
+    build::{build, BuildOptions},
+    clean::clean,
+    configure::configure,
+    export::export,
+    fetch::fetch,
+    init::init,
+    publish::publish,
+    query::query,
+    remove::remove,
+    shell::{run, script, shell},
+    stash::stash,
+    status::status,
+    update::{update, update_all},
+    verify::verify,
+};
 
 mod build;
 mod clean;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,9 +3,8 @@
 use loggerv;
 use openssl_probe;
 
-use lal;
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
-use lal::*;
+use lal::{self, *};
 use std::{env::current_dir, ops::Deref, path::Path, process};
 
 fn is_integer(v: String) -> Result<(), String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
 #[macro_use] extern crate clap;
 #[macro_use] extern crate log;
-extern crate loggerv;
-extern crate openssl_probe;
+use loggerv;
+use openssl_probe;
 
-extern crate lal;
+use lal;
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 use lal::*;
 use std::{env::current_dir, ops::Deref, path::Path, process};
@@ -27,7 +27,7 @@ fn result_exit<T>(name: &str, x: LalResult<T>) {
 
 // functions that work without a manifest, and thus can run without a set env
 fn handle_manifest_agnostic_cmds(
-    args: &ArgMatches,
+    args: &ArgMatches<'_>,
     cfg: &Config,
     component_dir: &Path,
     backend: &dyn Backend,
@@ -55,7 +55,7 @@ fn handle_manifest_agnostic_cmds(
 
 // functions that need a manifest, but do not depend on environment values
 fn handle_environment_agnostic_cmds(
-    args: &ArgMatches,
+    args: &ArgMatches<'_>,
     component_dir: &Path,
     mf: &Manifest,
     backend: &dyn Backend,
@@ -105,7 +105,7 @@ fn handle_environment_agnostic_cmds(
 }
 
 fn handle_network_cmds(
-    args: &ArgMatches,
+    args: &ArgMatches<'_>,
     component_dir: &Path,
     mf: &Manifest,
     backend: &dyn Backend,
@@ -144,7 +144,7 @@ fn handle_network_cmds(
 }
 
 fn handle_env_command(
-    args: &ArgMatches,
+    args: &ArgMatches<'_>,
     component_dir: &Path,
     cfg: &Config,
     env: &str,
@@ -214,7 +214,7 @@ fn handle_upgrade(args: &ArgMatches, cfg: &Config) {
 
 
 fn handle_docker_cmds(
-    args: &ArgMatches,
+    args: &ArgMatches<'_>,
     component_dir: &Path,
     mf: &Manifest,
     cfg: &Config,

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 // Need both the struct and the trait
 use super::{CliError, LalResult, Lockfile};
-use storage::Backend;
+use crate::storage::Backend;
 
 /// Publish a release build to the storage backend
 ///

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,7 +1,7 @@
 use std::io::{self, Write};
 
 use super::{CliError, LalResult};
-use storage::Backend;
+use crate::storage::Backend;
 
 /// Prints a list of versions associated with a component
 pub fn query(backend: &dyn Backend, _env: Option<&str>, component: &str, last: bool) -> LalResult<()> {

--- a/src/runners/docker.rs
+++ b/src/runners/docker.rs
@@ -1,6 +1,6 @@
 use std::{path::Path, process::Command, vec::Vec};
 
-use core::{CliError, Config, Container, LalResult};
+use crate::core::{CliError, Config, Container, LalResult};
 
 /// Flags for docker run that vary for different use cases
 ///

--- a/src/runners/native.rs
+++ b/src/runners/native.rs
@@ -1,6 +1,6 @@
 use std::{path::Path, process::Command, vec::Vec};
 
-use core::{CliError, LalResult};
+use crate::core::{CliError, LalResult};
 
 /// Runs an arbitrary command natively, without containerization
 pub fn native_run(mut command: Vec<String>, component_dir: &Path) -> LalResult<()> {

--- a/src/stash.rs
+++ b/src/stash.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use super::{CliError, LalResult, Lockfile, Manifest};
-use storage::CachedBackend;
+use crate::storage::CachedBackend;
 
 
 /// Saves current build `./OUTPUT` to the local cache under a specific name

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,6 +1,6 @@
 use super::{CliError, LalResult, Lockfile, Manifest};
-use ansi_term::{ANSIString, Colour};
 use crate::core::input;
+use ansi_term::{ANSIString, Colour};
 use std::path::Path;
 
 fn version_string(lf: Option<&Lockfile>, show_ver: bool, show_time: bool) -> ANSIString<'static> {

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,6 +1,6 @@
 use super::{CliError, LalResult, Lockfile, Manifest};
 use ansi_term::{ANSIString, Colour};
-use core::input;
+use crate::core::input;
 use std::path::Path;
 
 fn version_string(lf: Option<&Lockfile>, show_ver: bool, show_time: bool) -> ANSIString<'static> {

--- a/src/storage/artifactory.rs
+++ b/src/storage/artifactory.rs
@@ -20,7 +20,7 @@ use hyper_native_tls::NativeTlsClient;
 use serde_json;
 use sha1;
 
-use core::{CliError, LalResult};
+use crate::core::{CliError, LalResult};
 
 
 /// Artifactory credentials

--- a/src/storage/download.rs
+++ b/src/storage/download.rs
@@ -3,8 +3,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use core::{output, CliError, LalResult};
-use storage::{Backend, CachedBackend, Component};
+use crate::core::{output, CliError, LalResult};
+use crate::storage::{Backend, CachedBackend, Component};
 
 fn is_cached<T: Backend + ?Sized>(backend: &T, name: &str, version: u32, env: &str) -> bool {
     get_cache_dir(backend, name, version, env).is_dir()

--- a/src/storage/download.rs
+++ b/src/storage/download.rs
@@ -3,8 +3,10 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::core::{output, CliError, LalResult};
-use crate::storage::{Backend, CachedBackend, Component};
+use crate::{
+    core::{output, CliError, LalResult},
+    storage::{Backend, CachedBackend, Component},
+};
 
 fn is_cached<T: Backend + ?Sized>(backend: &T, name: &str, version: u32, env: &str) -> bool {
     get_cache_dir(backend, name, version, env).is_dir()

--- a/src/storage/local.rs
+++ b/src/storage/local.rs
@@ -8,7 +8,7 @@ use std::{
     vec::Vec,
 };
 
-use core::{config_dir, ensure_dir_exists_fresh, CliError, LalResult};
+use crate::core::{config_dir, ensure_dir_exists_fresh, CliError, LalResult};
 
 
 /// LocalBackend configuration options (currently none)

--- a/src/storage/traits.rs
+++ b/src/storage/traits.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use super::{ArtifactoryConfig, LocalConfig};
-use core::LalResult;
+use crate::core::LalResult;
 
 /// An enum struct for the currently configured `Backend`
 ///

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,6 +1,6 @@
 use super::{CliError, LalResult, Manifest};
-use std::{cmp::Ordering, path::Path};
 use crate::storage::CachedBackend;
+use std::{cmp::Ordering, path::Path};
 
 /// Update specific dependencies outside the manifest
 ///

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,6 +1,6 @@
 use super::{CliError, LalResult, Manifest};
 use std::{cmp::Ordering, path::Path};
-use storage::CachedBackend;
+use crate::storage::CachedBackend;
 
 /// Update specific dependencies outside the manifest
 ///

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1,5 +1,5 @@
 use super::{LalResult, Lockfile, Manifest};
-use input;
+use crate::input;
 use std::path::Path;
 
 /// Verifies that `./INPUT` satisfies all strictness conditions.

--- a/tests/cases/test_backend.rs
+++ b/tests/cases/test_backend.rs
@@ -1,4 +1,4 @@
-use common::*;
+use crate::common::*;
 use lal::Backend;
 use parameterized_macro::parameterized;
 use std::{fs, path::Path};

--- a/tests/cases/test_build.rs
+++ b/tests/cases/test_build.rs
@@ -1,4 +1,4 @@
-use common::*;
+use crate::common::*;
 use parameterized_macro::parameterized;
 
 #[parameterized(env_name = {"default", "alpine"})]

--- a/tests/cases/test_clean.rs
+++ b/tests/cases/test_clean.rs
@@ -1,4 +1,4 @@
-use common::*;
+use crate::common::*;
 use parameterized_macro::parameterized;
 
 #[parameterized(env_name = {"default", "alpine"})]

--- a/tests/cases/test_envs.rs
+++ b/tests/cases/test_envs.rs
@@ -1,4 +1,4 @@
-use common::*;
+use crate::common::*;
 use parameterized_macro::parameterized;
 use std::fs;
 

--- a/tests/cases/test_export.rs
+++ b/tests/cases/test_export.rs
@@ -1,4 +1,4 @@
-use common::*;
+use crate::common::*;
 use parameterized_macro::parameterized;
 use std::fs;
 

--- a/tests/cases/test_fetch.rs
+++ b/tests/cases/test_fetch.rs
@@ -1,4 +1,4 @@
-use common::*;
+use crate::common::*;
 use parameterized_macro::parameterized;
 
 #[parameterized(env_name = {"default", "alpine"})]

--- a/tests/cases/test_init.rs
+++ b/tests/cases/test_init.rs
@@ -1,4 +1,4 @@
-use common::*;
+use crate::common::*;
 use parameterized_macro::parameterized;
 use std::fs;
 

--- a/tests/cases/test_list.rs
+++ b/tests/cases/test_list.rs
@@ -1,4 +1,4 @@
-use common::*;
+use crate::common::*;
 use parameterized_macro::parameterized;
 
 #[parameterized(env_name = {"default", "alpine"})]

--- a/tests/cases/test_propagate.rs
+++ b/tests/cases/test_propagate.rs
@@ -1,4 +1,4 @@
-use common::*;
+use crate::common::*;
 use parameterized_macro::parameterized;
 use std::path::PathBuf;
 

--- a/tests/cases/test_publish.rs
+++ b/tests/cases/test_publish.rs
@@ -1,4 +1,4 @@
-use common::*;
+use crate::common::*;
 use parameterized_macro::parameterized;
 use std::path::Path;
 

--- a/tests/cases/test_query.rs
+++ b/tests/cases/test_query.rs
@@ -1,4 +1,4 @@
-use common::*;
+use crate::common::*;
 use parameterized_macro::parameterized;
 
 #[parameterized(env_name = {"default", "alpine"})]

--- a/tests/cases/test_remove.rs
+++ b/tests/cases/test_remove.rs
@@ -1,4 +1,4 @@
-use common::*;
+use crate::common::*;
 
 #[test]
 pub fn test_remove_dependencies_no_save() {

--- a/tests/cases/test_shell.rs
+++ b/tests/cases/test_shell.rs
@@ -1,4 +1,4 @@
-use common::*;
+use crate::common::*;
 use parameterized_macro::parameterized;
 
 #[parameterized(env_name = {"default", "alpine"})]

--- a/tests/cases/test_stash.rs
+++ b/tests/cases/test_stash.rs
@@ -1,4 +1,4 @@
-use common::*;
+use crate::common::*;
 use parameterized_macro::parameterized;
 
 #[parameterized(env_name = {"default", "alpine"})]

--- a/tests/cases/test_status.rs
+++ b/tests/cases/test_status.rs
@@ -1,4 +1,4 @@
-use common::*;
+use crate::common::*;
 use parameterized_macro::parameterized;
 use std::path::PathBuf;
 

--- a/tests/cases/test_update.rs
+++ b/tests/cases/test_update.rs
@@ -1,4 +1,4 @@
-use common::*;
+use crate::common::*;
 use parameterized_macro::parameterized;
 use std::path::{Path, PathBuf};
 

--- a/tests/cases/test_verify.rs
+++ b/tests/cases/test_verify.rs
@@ -1,4 +1,4 @@
-use common::*;
+use crate::common::*;
 use parameterized_macro::parameterized;
 
 #[parameterized(

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,8 +1,8 @@
-extern crate fs_extra;
-extern crate lal;
-extern crate loggerv;
-extern crate tempdir;
-extern crate walkdir;
+use fs_extra;
+use lal;
+use loggerv;
+use tempdir;
+
 
 use crate::common::{
     fs_extra::dir::{copy, CopyOptions},

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,7 +4,7 @@ extern crate loggerv;
 extern crate tempdir;
 extern crate walkdir;
 
-use common::{
+use crate::common::{
     fs_extra::dir::{copy, CopyOptions},
     loggerv::init_with_verbosity,
     tempdir::TempDir,

--- a/tests/testmain.rs
+++ b/tests/testmain.rs
@@ -1,5 +1,5 @@
-extern crate lal;
-extern crate parameterized_macro;
+
+
 
 mod cases;
 mod common;

--- a/tests/testmain.rs
+++ b/tests/testmain.rs
@@ -1,5 +1,2 @@
-
-
-
 mod cases;
 mod common;


### PR DESCRIPTION
Most of these changes were applied by the automatic conversion tools.

However, there are still a few places that need to be manually updated.
info: https://doc.rust-lang.org/stable/edition-guide/rust-2018/module-system/path-clarity.html