### PR TITLE
Unparmeterize backend tests

### DIFF
--- a/tests/cases/test_backend.rs
+++ b/tests/cases/test_backend.rs
@@ -1,14 +1,10 @@
 use crate::common::*;
 use lal::Backend;
-use parameterized_macro::parameterized;
 use std::{fs, path::Path};
 
-#[parameterized(env_name = {"default", "alpine"})]
-pub fn test_configure_backend(env_name: &str) {
+#[test]
+pub fn test_configure_backend() {
     let state = setup();
-    if !cfg!(feature = "docker") && env_name == "alpine" {
-        return;
-    }
 
     assert_eq!(
         fs::canonicalize(Path::new(&state.backend.get_cache_dir())).unwrap(),


### PR DESCRIPTION
This test doesn't need to test the runners, so it doesn't need to have parameters.