### PR TITLE
Use `dyn Trait` syntax, remove `?Sized`

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -4,8 +4,8 @@ use super::{CliError, LalResult};
 use crate::storage::CachedBackend;
 
 /// Export a specific component from the storage backend
-pub fn export<T: CachedBackend + ?Sized>(
-    backend: &T,
+pub fn export(
+    backend: &dyn CachedBackend,
     comp: &str,
     output: &Path,
     _env: Option<&str>,

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -14,10 +14,10 @@ fn clean_input(component_dir: &Path) {
 ///
 /// This will read, and HTTP GET all the dependencies at the specified versions.
 /// If the `core` bool is set, then `devDependencies` are not installed.
-pub fn fetch<T: CachedBackend + ?Sized>(
+pub fn fetch(
     component_dir: &Path,
     manifest: &Manifest,
-    backend: &T,
+    backend: &dyn CachedBackend,
     core: bool,
     env: &str,
 ) -> LalResult<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ fn handle_manifest_agnostic_cmds(
     args: &ArgMatches<'_>,
     cfg: &Config,
     component_dir: &Path,
-    backend: &dyn Backend,
+    backend: &dyn CachedBackend,
     explicit_env: Option<&str>,
 ) {
     let res = if let Some(a) = args.subcommand_matches("export") {
@@ -57,7 +57,7 @@ fn handle_environment_agnostic_cmds(
     args: &ArgMatches<'_>,
     component_dir: &Path,
     mf: &Manifest,
-    backend: &dyn Backend,
+    backend: &dyn CachedBackend,
 ) {
     let res = if let Some(a) = args.subcommand_matches("status") {
         lal::status(
@@ -107,7 +107,7 @@ fn handle_network_cmds(
     args: &ArgMatches<'_>,
     component_dir: &Path,
     mf: &Manifest,
-    backend: &dyn Backend,
+    backend: &dyn CachedBackend,
     env: &str,
 ) {
     let res = if let Some(a) = args.subcommand_matches("update") {
@@ -620,7 +620,7 @@ fn main() {
         .unwrap();
 
     // Create a storage backend (something that implements storage/traits.rs)
-    let backend: Box<dyn Backend> = match config.backend {
+    let backend: Box<dyn CachedBackend> = match config.backend {
         BackendConfiguration::Artifactory(ref art_cfg) => {
             Box::new(ArtifactoryBackend::new(&art_cfg, &config.cache))
         }

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -2,17 +2,17 @@ use std::path::Path;
 
 // Need both the struct and the trait
 use super::{CliError, LalResult, Lockfile};
-use crate::storage::Backend;
+use crate::storage::CachedBackend;
 
 /// Publish a release build to the storage backend
 ///
 /// Meant to be done after a `lal build -r <component>`
 /// and requires publish credentials in the local `Config`.
-pub fn publish<T: Backend + ?Sized>(
+pub fn publish(
     home: Option<&Path>,
     component_dir: &Path,
     name: &str,
-    backend: &T,
+    backend: &dyn CachedBackend,
 ) -> LalResult<()> {
     let artdir = component_dir.join("./ARTIFACT");
     let tarball = artdir.join(format!("{}.tar.gz", name));

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,10 +1,10 @@
 use std::io::{self, Write};
 
 use super::{CliError, LalResult};
-use crate::storage::Backend;
+use crate::storage::CachedBackend;
 
 /// Prints a list of versions associated with a component
-pub fn query(backend: &dyn Backend, _env: Option<&str>, component: &str, last: bool) -> LalResult<()> {
+pub fn query(backend: &dyn CachedBackend, _env: Option<&str>, component: &str, last: bool) -> LalResult<()> {
     if component.to_lowercase() != component {
         return Err(CliError::InvalidComponentName(component.into()));
     }

--- a/src/stash.rs
+++ b/src/stash.rs
@@ -10,9 +10,9 @@ use crate::storage::CachedBackend;
 /// then copies this to `~/.lal/cache/stash/${name}/`.
 ///
 /// This file can then be installed via `update` using a component=${name} argument.
-pub fn stash<T: CachedBackend + ?Sized>(
+pub fn stash(
     component_dir: &Path,
-    backend: &T,
+    backend: &dyn CachedBackend,
     mf: &Manifest,
     name: &str,
 ) -> LalResult<()> {

--- a/src/storage/download.rs
+++ b/src/storage/download.rs
@@ -8,11 +8,11 @@ use crate::{
     storage::{Backend, CachedBackend, Component},
 };
 
-fn is_cached<T: Backend + ?Sized>(backend: &T, name: &str, version: u32, env: &str) -> bool {
+fn is_cached(backend: &dyn Backend, name: &str, version: u32, env: &str) -> bool {
     get_cache_dir(backend, name, version, env).is_dir()
 }
 
-fn get_cache_dir<T: Backend + ?Sized>(backend: &T, name: &str, version: u32, env: &str) -> PathBuf {
+fn get_cache_dir(backend: &dyn Backend, name: &str, version: u32, env: &str) -> PathBuf {
     let cache = backend.get_cache_dir();
     Path::new(&cache)
         .join("environments")
@@ -21,8 +21,8 @@ fn get_cache_dir<T: Backend + ?Sized>(backend: &T, name: &str, version: u32, env
         .join(version.to_string())
 }
 
-fn stored_tarball_location<T: Backend + ?Sized>(
-    backend: &T,
+fn stored_tarball_location(
+    backend: &dyn Backend,
     name: &str,
     version: u32,
     env: &str,
@@ -78,10 +78,7 @@ fn extract_tarball_to_input(tarname: PathBuf, component_dir: &Path, component: &
 ///
 /// Most subcommands should be OK with just using this trait rather than using
 /// `Backend` directly as this does the stuff you normally would want done.
-impl<T: ?Sized> CachedBackend for T
-where
-    T: Backend,
-{
+impl<T: Backend> CachedBackend for T {
     /// Get the latest versions of a component across all supported environments
     ///
     /// Because the versions have to be available in all environments, these numbers may

--- a/src/storage/traits.rs
+++ b/src/storage/traits.rs
@@ -82,7 +82,7 @@ pub trait Backend {
 /// A secondary trait that builds upon the Backend trait
 ///
 /// This wraps the common fetch commands in a caching layer on the cache dir.
-pub trait CachedBackend {
+pub trait CachedBackend: Backend {
     /// Get the latest version of a component across all supported environments
     fn get_latest_supported_versions(&self, name: &str, environments: Vec<String>) -> LalResult<Vec<u32>>;
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -10,10 +10,10 @@ use std::{cmp::Ordering, path::Path};
 /// If installation was successful, the fetched tarballs are unpacked into `./INPUT`.
 /// If one `save` or `savedev` was set, the fetched versions are also updated in the
 /// manifest. This provides an easy way to not have to deal with strict JSON manually.
-pub fn update<T: CachedBackend + ?Sized>(
+pub fn update(
     component_dir: &Path,
     manifest: &Manifest,
-    backend: &T,
+    backend: &dyn CachedBackend,
     components: Vec<String>,
     save: bool,
     savedev: bool,
@@ -116,10 +116,10 @@ pub fn update<T: CachedBackend + ?Sized>(
 /// This will pass all dependencies or devDependencies to update.
 /// If the save flag is set, then the manifest will be updated correctly.
 /// I.e. dev updates will update only the dev portions of the manifest.
-pub fn update_all<T: CachedBackend + ?Sized>(
+pub fn update_all(
     component_dir: &Path,
     manifest: &Manifest,
-    backend: &T,
+    backend: &dyn CachedBackend,
     save: bool,
     dev: bool,
     env: &str,

--- a/tests/common/fetch.rs
+++ b/tests/common/fetch.rs
@@ -1,19 +1,19 @@
 use std::path::Path;
 
-pub fn fetch_input<T: lal::CachedBackend + lal::Backend>(
+pub fn fetch_input(
     component_dir: &Path,
     env_name: &str,
-    backend: &T,
+    backend: &dyn lal::CachedBackend,
 ) -> lal::LalResult<()> {
     let manifest = lal::Manifest::read(&component_dir)?;
 
     lal::fetch(&component_dir, &manifest, backend, true, &env_name)
 }
 
-pub fn fetch_dev_input<T: lal::CachedBackend + lal::Backend>(
+pub fn fetch_dev_input(
     component_dir: &Path,
     env_name: &str,
-    backend: &T,
+    backend: &dyn lal::CachedBackend,
 ) -> lal::LalResult<()> {
     let manifest = lal::Manifest::read(&component_dir)?;
 

--- a/tests/common/publish.rs
+++ b/tests/common/publish.rs
@@ -1,8 +1,8 @@
 use std::path::Path;
 
-pub fn publish_release<T: lal::CachedBackend + lal::Backend>(
+pub fn publish_release(
     component_dir: &Path,
-    backend: &T,
+    backend: &dyn lal::CachedBackend,
     home: &Path,
 ) -> lal::LalResult<()> {
     let manifest = lal::Manifest::read(&component_dir)?;

--- a/tests/common/stash.rs
+++ b/tests/common/stash.rs
@@ -1,8 +1,8 @@
 use std::path::Path;
 
-pub fn stash<T: lal::CachedBackend + lal::Backend>(
+pub fn stash(
     component_dir: &Path,
-    backend: &T,
+    backend: &dyn lal::CachedBackend,
     stash_name: &str,
 ) -> lal::LalResult<()> {
     let manifest = lal::Manifest::read(&component_dir)?;

--- a/tests/common/update.rs
+++ b/tests/common/update.rs
@@ -1,9 +1,9 @@
 use std::path::Path;
 
-pub fn update<T: lal::CachedBackend + lal::Backend>(
+pub fn update(
     component_dir: &Path,
     env_name: &str,
-    backend: &T,
+    backend: &dyn lal::CachedBackend,
     components: Vec<&str>,
 ) -> lal::LalResult<()> {
     let manifest = lal::Manifest::read(&component_dir)?;
@@ -24,19 +24,19 @@ pub fn update<T: lal::CachedBackend + lal::Backend>(
     )
 }
 
-pub fn update_all<T: lal::CachedBackend + lal::Backend>(
+pub fn update_all(
     component_dir: &Path,
     env_name: &str,
-    backend: &T,
+    backend: &dyn lal::CachedBackend,
 ) -> lal::LalResult<()> {
     let manifest = lal::Manifest::read(&component_dir)?;
     lal::update_all(&component_dir, &manifest, backend, false, false, &env_name)
 }
 
-pub fn update_with_save<T: lal::CachedBackend + lal::Backend>(
+pub fn update_with_save(
     component_dir: &Path,
     env_name: &str,
-    backend: &T,
+    backend: &dyn lal::CachedBackend,
     components: Vec<&str>,
     save: bool,
     savedev: bool,
@@ -59,10 +59,10 @@ pub fn update_with_save<T: lal::CachedBackend + lal::Backend>(
     )
 }
 
-pub fn update_all_with_save<T: lal::CachedBackend + lal::Backend>(
+pub fn update_all_with_save(
     component_dir: &Path,
     env_name: &str,
-    backend: &T,
+    backend: &dyn lal::CachedBackend,
     save: bool,
     savedev: bool,
 ) -> lal::LalResult<()> {


### PR DESCRIPTION
As per RFC2113 `&dyn Trait` syntax is now the preferred idiom
for many of the use-cases we have for passing the Backends around.

https://github.com/rust-lang/rfcs/blob/master/text/2113-dyn-trait-syntax.md#the-current-syntax-is-often-ambiguous-and-confusing

---
For us, this means that patterns such as

```
fn func<T: CachedBackend + ?Sized>(backend: &T)
```
becomes
```
fn func(backend: &dyn CachedBackend)
```

---

The `?Sized` trait bound can also be removed.
In most areas of the code, we use Boxed trait objects, which are `Sized`.