### PR TITLE
Clean up clippy warnings

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,0 +1,22 @@
+on: 'push'
+name: 'Cargo Clippy'
+
+jobs:
+  clippy:
+    name: 'Cargo Clippy'
+    runs-on: 'ubuntu-latest'
+
+    steps:
+    - uses: 'actions/checkout@v2'
+    - name: 'Install Stable Toolchain'
+      uses: 'actions-rs/toolchain@v1'
+      with:
+        toolchain: 'stable'
+        target: 'x86_64-unknown-linux-musl'
+        profile: 'minimal'
+        components: 'clippy'
+
+    - uses: 'actions-rs/clippy-check@v1'
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        args: '--all-features'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,7 +17,6 @@ jobs:
         toolchain: 'stable'
         target: 'x86_64-unknown-linux-musl'
         profile: 'minimal'
-        components: 'clippy'
 
     - name: 'Login to Docker Hub'
       uses: 'docker/login-action@v1'
@@ -104,5 +103,4 @@ jobs:
           ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
           ${{ runner.os }}-cargo-
 
-    - run: 'cargo clippy'
     - run: 'cargo doc --no-deps'

--- a/src/app.rs
+++ b/src/app.rs
@@ -306,5 +306,5 @@ pub fn new<'a>() -> App<'a, 'a> {
             .subcommand(SubCommand::with_name("upgrade").about("Attempts to upgrade lal from artifactory"));
     }
 
-    return app;
+    app
 }

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1,5 +1,4 @@
 use chrono::UTC;
-use serde_json;
 use std::{
     collections::BTreeMap,
     env, fs,
@@ -185,7 +184,7 @@ impl Config {
     #[cfg(feature = "upgrade")]
     pub fn performed_upgrade(&mut self) -> LalResult<()> {
         self.lastUpgrade = UTC::now().to_rfc3339();
-        Ok(self.write(true, None)?)
+        self.write(true, None)
     }
 
     /// Overwrite `~/.lal/config` with serialized data from this struct

--- a/src/core/errors.rs
+++ b/src/core/errors.rs
@@ -1,5 +1,3 @@
-use hyper;
-use serde_json;
 use std::{fmt, io};
 
 /// The one and only error type for the lal library

--- a/src/core/input.rs
+++ b/src/core/input.rs
@@ -1,6 +1,5 @@
 #![allow(missing_docs)]
 
-use serde_json;
 use std::{collections::BTreeMap, fs::File, io::prelude::*, path::Path};
 
 use walkdir::WalkDir;
@@ -183,7 +182,7 @@ pub fn verify_consistent_dependency_versions(lf: &Lockfile, m: &Manifest) -> Lal
         if vers.len() != 1 && m.dependencies.contains_key(&name) {
             warn!(
                 "Multiple version requirements on {} found in lockfile",
-                name.clone()
+                name
             );
             warn!(
                 "If you are trying to propagate {0} into the tree, \
@@ -201,7 +200,7 @@ pub fn verify_environment_consistency(lf: &Lockfile, env: &str) -> LalResult<()>
     for (name, envs) in lf.find_all_environments() {
         debug!("Found environment(s) for {} as {:?}", name, envs);
         if envs.len() != 1 {
-            warn!("Multiple environments used to build {}", name.clone());
+            warn!("Multiple environments used to build {}", name);
             return Err(CliError::MultipleEnvironments(name));
         } else {
             let used_env = envs.iter().next().unwrap();

--- a/src/core/lockfile.rs
+++ b/src/core/lockfile.rs
@@ -1,11 +1,9 @@
 use chrono::UTC;
-use rand;
-use serde_json;
 
 use std::{
     fs::File,
     io::prelude::*,
-    path::{Path, PathBuf},
+    path::Path,
 };
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -74,7 +72,7 @@ impl Lockfile {
     }
 
     /// Opened lockfile at a path
-    pub fn from_path(lock_path: &PathBuf, name: &str) -> LalResult<Self> {
+    pub fn from_path(lock_path: &Path, name: &str) -> LalResult<Self> {
         if !lock_path.exists() {
             return Err(CliError::MissingLockfile(name.to_string()));
         }
@@ -86,7 +84,7 @@ impl Lockfile {
     /// A reader from ARTIFACT directory
     pub fn release_build(component_dir: &Path) -> LalResult<Self> {
         let lpath = component_dir.join("ARTIFACT").join("lockfile.json");
-        Ok(Lockfile::from_path(&lpath, "release build")?)
+        Lockfile::from_path(&lpath, "release build")
     }
 
     // Helper constructor for input populator below
@@ -95,7 +93,7 @@ impl Lockfile {
             .join("./INPUT")
             .join(component)
             .join("lockfile.json");
-        Ok(Lockfile::from_path(&lock_path, component)?)
+        Lockfile::from_path(&lock_path, component)
     }
 
     /// Read all the lockfiles in INPUT to generate the full lockfile

--- a/src/core/manifest.rs
+++ b/src/core/manifest.rs
@@ -1,4 +1,3 @@
-use serde_json;
 use std::{
     collections::BTreeMap,
     fs::{self, File},
@@ -10,7 +9,7 @@ use std::{
 use super::{CliError, LalResult};
 
 /// A startup helper used in a few places
-pub fn create_lal_subdir(pwd: &PathBuf) -> LalResult<()> {
+pub fn create_lal_subdir(pwd: &Path) -> LalResult<()> {
     let loc = pwd.join(".lal");
     if !loc.is_dir() {
         fs::create_dir(&loc)?
@@ -73,7 +72,7 @@ impl Default for ManifestLocation {
 }
 impl ManifestLocation {
     /// Generate path for Manifest assuming pwd is the root
-    pub fn as_path(&self, pwd: &PathBuf) -> PathBuf {
+    pub fn as_path(&self, pwd: &Path) -> PathBuf {
         match *self {
             ManifestLocation::RepoRoot => pwd.join("manifest.json"),
             ManifestLocation::LalSubfolder => pwd.join(".lal/manifest.json"),
@@ -83,7 +82,7 @@ impl ManifestLocation {
     /// Find the manifest file
     ///
     /// Looks first in `./.lal/manifest.json` and falls back to `./manifest.json`
-    pub fn identify(pwd: &PathBuf) -> LalResult<ManifestLocation> {
+    pub fn identify(pwd: &Path) -> LalResult<ManifestLocation> {
         if ManifestLocation::LalSubfolder.as_path(pwd).exists() {
             // Show a warning if we have two manifests - we only use the new one then
             // This could happen on other codebases - some javascript repos use manifest.json
@@ -131,11 +130,11 @@ impl Manifest {
 
     /// Read a manifest file in component dir
     pub fn read(component_dir: &Path) -> LalResult<Manifest> {
-        Ok(Manifest::read_from(&component_dir.to_path_buf())?)
+        Manifest::read_from(&component_dir.to_path_buf())
     }
 
     /// Read a manifest file in an arbitrary path
-    pub fn read_from(pwd: &PathBuf) -> LalResult<Manifest> {
+    pub fn read_from(pwd: &Path) -> LalResult<Manifest> {
         let mpath = ManifestLocation::identify(pwd)?.as_path(pwd);
         trace!("Using manifest in {}", mpath.display());
         let mut f = File::open(&mpath)?;

--- a/src/core/sticky.rs
+++ b/src/core/sticky.rs
@@ -1,4 +1,3 @@
-use serde_json;
 use std::{
     fs,
     io::prelude::{Read, Write},

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,5 @@
 #[macro_use] extern crate clap;
 #[macro_use] extern crate log;
-use loggerv;
-use openssl_probe;
 
 use clap::ArgMatches;
 use lal::{self, *};
@@ -239,7 +237,7 @@ fn handle_docker_cmds(
             printonly: a.is_present("print"),
             x11_forwarding: a.is_present("x11"),
             host_networking: a.is_present("net-host"),
-            env_vars: values_t!(a.values_of("env-var"), String).unwrap_or_else(|_| vec![]),
+            env_vars: values_t!(a.values_of("env-var"), String).unwrap_or_default(),
         };
         lal::build(&component_dir, cfg, mf, &bopts, env.into(), modes)
     } else if let Some(a) = args.subcommand_matches("shell") {
@@ -252,7 +250,7 @@ fn handle_docker_cmds(
             printonly: a.is_present("print"),
             x11_forwarding: a.is_present("x11"),
             host_networking: a.is_present("net-host"),
-            env_vars: values_t!(a.values_of("env-var"), String).unwrap_or_else(|_| vec![]),
+            env_vars: values_t!(a.values_of("env-var"), String).unwrap_or_default(),
         };
         lal::shell(
             cfg,
@@ -272,7 +270,7 @@ fn handle_docker_cmds(
             printonly: a.is_present("print"),
             x11_forwarding: a.is_present("x11"),
             host_networking: a.is_present("net-host"),
-            env_vars: values_t!(a.values_of("env-var"), String).unwrap_or_else(|_| vec![]),
+            env_vars: values_t!(a.values_of("env-var"), String).unwrap_or_default(),
         };
         lal::script(
             cfg,
@@ -397,16 +395,15 @@ fn main() {
     let environment = handle_env_command(&args, &component_dir, &config, &env, &stickies);
 
     // Warn users who are using an unsupported environment
+    let sub = args.subcommand_name().unwrap();
     if !manifest
         .supportedEnvironments
         .clone()
         .into_iter()
         .any(|e| e == env)
     {
-        let sub = args.subcommand_name().unwrap();
         warn!("Running {} command in unsupported {} environment", sub, env);
     } else {
-        let sub = args.subcommand_name().unwrap();
         debug!("Running {} command in supported {} environent", sub, env);
     }
 

--- a/src/propagate.rs
+++ b/src/propagate.rs
@@ -1,5 +1,4 @@
 use super::{LalResult, Lockfile, Manifest};
-use serde_json;
 use std::{collections::BTreeSet, path::Path};
 
 

--- a/src/storage/artifactory.rs
+++ b/src/storage/artifactory.rs
@@ -17,8 +17,6 @@ use hyper::{
     Client,
 };
 use hyper_native_tls::NativeTlsClient;
-use serde_json;
-use sha1;
 
 use crate::core::{CliError, LalResult};
 
@@ -76,7 +74,7 @@ fn hyper_req(url: &str) -> LalResult<String> {
 }
 
 // simple request downloader
-pub fn http_download_to_path(url: &str, save: &PathBuf) -> LalResult<()> {
+pub fn http_download_to_path(url: &str, save: &Path) -> LalResult<()> {
     debug!("GET {}", url);
     let client = Client::with_connector(HttpsConnector::new(NativeTlsClient::new().unwrap()));
     let mut res = client.get(url).send()?;
@@ -398,7 +396,7 @@ impl Backend for ArtifactoryBackend {
         self.cache.clone()
     }
 
-    fn raw_fetch(&self, url: &str, dest: &PathBuf) -> LalResult<()> {
+    fn raw_fetch(&self, url: &str, dest: &Path) -> LalResult<()> {
         http_download_to_path(url, dest)
     }
 }

--- a/src/storage/local.rs
+++ b/src/storage/local.rs
@@ -144,7 +144,7 @@ impl Backend for LocalBackend {
         self.cache.clone()
     }
 
-    fn raw_fetch(&self, src: &str, dest: &PathBuf) -> LalResult<()> {
+    fn raw_fetch(&self, src: &str, dest: &Path) -> LalResult<()> {
         debug!("raw fetch {} -> {}", src, dest.display());
         fs::copy(src, dest)?;
         Ok(())

--- a/src/storage/traits.rs
+++ b/src/storage/traits.rs
@@ -71,7 +71,7 @@ pub trait Backend {
     /// Raw fetch of location to a destination
     ///
     /// location can be a HTTPS url / a system path / etc (depending on the backend)
-    fn raw_fetch(&self, location: &str, dest: &PathBuf) -> LalResult<()>;
+    fn raw_fetch(&self, location: &str, dest: &Path) -> LalResult<()>;
 
     /// Return the base directory to be used to dump cached downloads
     ///


### PR DESCRIPTION
As part of this commit, all warnings have been cleaned
up as per the suggested recommendations from clippy.

- removing unnecessary clones on Strings
- removing unnecessary `use` statements
- Switching &PathBuf to %Path in functions
- removing unnecessary Ok/Try for implicit returns